### PR TITLE
Update Decoder documentation format to reStructuredText

### DIFF
--- a/GlossExample/Pods/Gloss/Pod/Classes/Decoder.swift
+++ b/GlossExample/Pods/Gloss/Pod/Classes/Decoder.swift
@@ -32,10 +32,10 @@ public struct Decoder {
     
     /**
     Returns function to decode JSON to value type
-    
-    - parameter key: JSON key used to set value
-    
-    - returns: Function decoding JSON to an optional value type
+
+    :param: key JSON key used to set value
+
+    :returns: Function decoding JSON to an optional value type
     */
     public static func decode<T>(key: String) -> JSON -> T? {
         return {
@@ -52,10 +52,10 @@ public struct Decoder {
     /**
     Returns function to decode JSON to value type
     for objects that conform to the Glossy protocol
-    
-    - parameter key: JSON key used to set value
-    
-    - returns: Function decoding JSON to an optional value type
+
+    :param: key JSON key used to set value
+
+    :returns: Function decoding JSON to an optional value type
     */
     public static func decode<T: Decodable>(key: String) -> JSON -> T? {
         return {
@@ -73,10 +73,10 @@ public struct Decoder {
     /**
     Returns function to decode JSON to array
     of enum values
-    
-    - parameter key: JSON key used to set value
-    
-    - returns: Function decoding JSON to an optional array
+
+    :param: key JSON key used to set value
+
+    :returns: Function decoding JSON to an optional array
     */
     public static func decodeArray<T: RawRepresentable>(key: String) -> JSON -> [T]? {
         return {
@@ -101,10 +101,10 @@ public struct Decoder {
     /**
     Returns function to decode JSON to array
     for objects that conform to the Glossy protocol
-    
-    - parameter key: JSON key used to set value
-    
-    - returns: Function decoding JSON to an optinal array
+
+    :param: key JSON key used to set value
+
+    :returns: Function decoding JSON to an optional array
     */
     public static func decodeArray<T: Decodable>(key: String) -> JSON -> [T]? {
         return {
@@ -126,11 +126,11 @@ public struct Decoder {
     
     /**
     Returns function to decode JSON to date
-    
-    - parameter key:           JSON key used to set value
-    - parameter dateFormatter: Formatter used to format date
-    
-    - returns: Function decoding JSON to an optional date
+
+    :param: key           JSON key used to set value
+    :param: dateFormatter Formatter used to format date
+
+    :returns: Function decoding JSON to an optional date
     */
     public static func decodeDate(key: String, dateFormatter: NSDateFormatter) -> JSON -> NSDate? {
         return {
@@ -146,11 +146,10 @@ public struct Decoder {
     
     /**
     Returns function to decode JSON to ISO8601 date
-    
-    - parameter key:           JSON key used to set value
-    - parameter dateFormatter: Formatter with ISO8601 format
-    
-    - returns: Function decoding JSON to an optional ISO8601 date
+
+    :param: key JSON key used to set value
+
+    :returns: Function decoding JSON to an optional ISO8601 date
     */
     public static func decodeDateISO8601(key: String) -> JSON -> NSDate? {
         let dateFormatter = NSDateFormatter()
@@ -162,10 +161,10 @@ public struct Decoder {
     
     /**
     Returns function to decode JSON to enum value
-    
-    - parameter key: JSON key used to set value
-    
-    - returns: Function decoding JSON to an optional enum value
+
+    :param: key JSON key used to set value
+
+    :returns: Function decoding JSON to an optional enum value
     */
     public static func decodeEnum<T: RawRepresentable>(key: String) -> JSON -> T? {
         return {
@@ -181,10 +180,10 @@ public struct Decoder {
     
     /**
     Returns function to decode JSON to URL
-    
-    - parameter key: JSON key used to set value
-    
-    - returns: Function decoding JSON to an optional URL
+
+    :param: key JSON key used to set value
+
+    :returns: Function decoding JSON to an optional URL
     */
     public static func decodeURL(key: String) -> JSON -> NSURL? {
         return {
@@ -202,10 +201,10 @@ public struct Decoder {
     
     /**
     Returns function to decode JSON to value type
-    
-    - parameter key: JSON key used to set value
-    
-    - returns: Function decoding JSON to a value type
+
+    :param: key JSON key used to set value
+
+    :returns: Function decoding JSON to a value type
     */
     public static func forceDecode<T>(key: String) -> JSON -> T {
         return { return decode(key)($0)! }
@@ -214,10 +213,10 @@ public struct Decoder {
     /**
     Returns function to decode JSON to value type
     for objects that conform to the Glossy protocol
-    
-    - parameter key: JSON key used to set value
-    
-    - returns: Function decoding JSON to a value type
+
+    :param: key JSON key used to set value
+
+    :returns: Function decoding JSON to a value type
     */
     public static func forceDecode<T: Decodable>(key: String) -> JSON -> T {
         return { return decode(key)($0)! }
@@ -226,10 +225,10 @@ public struct Decoder {
     /**
     Returns function to decode JSON to array
     of enum values
-    
-    - parameter key: JSON key used to set value
-    
-    - returns: Function decoding JSON to a array
+
+    :param: key JSON key used to set value
+
+    :returns: Function decoding JSON to a array
     */
     public static func forceDecodeArray<T: RawRepresentable>(key: String) -> JSON -> [T] {
         return { return decodeArray(key)($0)! }
@@ -238,10 +237,10 @@ public struct Decoder {
     /**
     Returns function to decode JSON to array
     for objects that conform to the Glossy protocol
-    
-    - parameter key: JSON key used to set value
-    
-    - returns: Function decoding JSON to a array
+
+    :param: key JSON key used to set value
+
+    :returns: Function decoding JSON to a array
     */
     public static func forceDecodeArray<T: Decodable>(key: String) -> JSON -> [T] {
         return { return decodeArray(key)($0)! }
@@ -249,11 +248,11 @@ public struct Decoder {
     
     /**
     Returns function to decode JSON to date
-    
-    - parameter key:           JSON key used to set value
-    - parameter dateFormatter: Formatter used to format date
-    
-    - returns: Function decoding JSON to a date
+
+    :param: key           JSON key used to set value
+    :param: dateFormatter Formatter used to format date
+
+    :returns: Function decoding JSON to a date
     */
     public static func forceDecodeDate(key: String, dateFormatter: NSDateFormatter) -> JSON -> NSDate {
         return { return decodeDate(key, dateFormatter: dateFormatter)($0)! }
@@ -261,11 +260,10 @@ public struct Decoder {
     
     /**
     Returns function to decode JSON to ISO8601 date
-    
-    - parameter key:           JSON key used to set value
-    - parameter dateFormatter: Formatter with ISO8601 format
-    
-    - returns: Function decoding JSON to a ISO8601 date
+
+    :param: key JSON key used to set value
+
+    :returns: Function decoding JSON to a ISO8601 date
     */
     public static func forceDecodeDateISO8601(key: String) -> JSON -> NSDate {
         let dateFormatter = NSDateFormatter()
@@ -277,10 +275,10 @@ public struct Decoder {
     
     /**
     Returns function to decode JSON to enum value
-    
-    - parameter key: JSON key used to set value
-    
-    - returns: Function decoding JSON to an enum value
+
+    :param: key JSON key used to set value
+
+    :returns: Function decoding JSON to an enum value
     */
     public static func forceDecodeEnum<T: RawRepresentable>(key: String) -> JSON -> T {
         return { return decodeEnum(key)($0)! }
@@ -288,10 +286,10 @@ public struct Decoder {
     
     /**
     Returns function to decode JSON to URL
-    
-    - parameter key: JSON key used to set value
-    
-    - returns: Function decoding JSON to a URL
+
+    :param: key JSON key used to set value
+
+    :returns: Function decoding JSON to a URL
     */
     public static func forceDecodeURL(key: String) -> JSON -> NSURL {
         return { return decodeURL(key)($0)! }


### PR DESCRIPTION
This pull-request updates the documentation format in `Decoder.swift` to use [reStructuredText](http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#field-lists) which Xcode parses correctly.   

This makes Quick help go from:
<img width="595" alt="screenshot 2015-08-22 02 55 53" src="https://cloud.githubusercontent.com/assets/163534/9423463/7e2fcfac-4879-11e5-9d1b-7ba9553f24af.png">

to:
<img width="630" alt="screenshot 2015-08-22 02 54 38" src="https://cloud.githubusercontent.com/assets/163534/9423465/88fdab98-4879-11e5-90fd-b84fafd5da9c.png">

You can read more about this change in http://nshipster.com/swift-documentation/