### PR TITLE
Add valueForKeyPathCoding

### DIFF
--- a/Sources/Gloss.xcodeproj/project.pbxproj
+++ b/Sources/Gloss.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		35497DF41C5F8CEB00D1E20D /* KeyPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35497DF31C5F8CEB00D1E20D /* KeyPathTests.swift */; };
 		A0E6A1721C119AB800A4DC1F /* Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF300A11BDCA4B6003FBF15 /* Decoder.swift */; };
 		A0E6A1731C119AB800A4DC1F /* Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF300A21BDCA4B6003FBF15 /* Dictionary.swift */; };
 		A0E6A1741C119AB800A4DC1F /* Encoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF300A31BDCA4B6003FBF15 /* Encoder.swift */; };
@@ -46,6 +47,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		35497DF31C5F8CEB00D1E20D /* KeyPathTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyPathTests.swift; sourceTree = "<group>"; };
 		A04168E71C0DF69900269A6A /* Gloss.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Gloss.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC39BF611B8A7AD200088CE0 /* Gloss.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Gloss.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC39BF641B8A7AD200088CE0 /* Gloss.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Gloss.h; sourceTree = "<group>"; };
@@ -141,6 +143,7 @@
 			isa = PBXGroup;
 			children = (
 				DC39BF701B8A7AD200088CE0 /* GlossTests.swift */,
+				35497DF31C5F8CEB00D1E20D /* KeyPathTests.swift */,
 				DC39BF721B8A7AD200088CE0 /* Info.plist */,
 			);
 			path = GlossTests;
@@ -389,6 +392,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				35497DF41C5F8CEB00D1E20D /* KeyPathTests.swift in Sources */,
 				DC39BF711B8A7AD200088CE0 /* GlossTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Gloss/Decoder.swift
+++ b/Sources/Gloss/Decoder.swift
@@ -43,7 +43,7 @@ public struct Decoder {
         return {
             json in
             
-            if let value = json[key] as? T {
+            if let value = json.valueForKeyPath(key) as? T {
                 return value
             }
             

--- a/Sources/Gloss/Dictionary.swift
+++ b/Sources/Gloss/Dictionary.swift
@@ -33,8 +33,13 @@ extension Dictionary {
     :parameter: other Dictionary to add entries from
     */
     public mutating func add(other: Dictionary) -> () {
-        for (key,value) in other {
-            self.updateValue(value, forKey:key)
+        for (key, value) in other {
+            if var previousValue = self[key] as? Dictionary, let currentValue = value as? Dictionary {
+                previousValue.add(currentValue)
+                self.updateValue(previousValue as! Value, forKey:key)
+            } else {
+                self.updateValue(value, forKey:key)
+            }
         }
     }
     

--- a/Sources/Gloss/Dictionary.swift
+++ b/Sources/Gloss/Dictionary.swift
@@ -34,9 +34,8 @@ extension Dictionary {
     */
     public mutating func add(other: Dictionary) -> () {
         for (key, value) in other {
-            if var previousValue = self[key] as? Dictionary, let currentValue = value as? Dictionary {
-                previousValue.add(currentValue)
-                self.updateValue(previousValue as! Value, forKey:key)
+            if let key = key as? String {
+                self.setValue(value, forKeyPath: key)
             } else {
                 self.updateValue(value, forKey:key)
             }
@@ -50,7 +49,7 @@ extension Dictionary {
      :parameter: val     value to set
      :parameter: keyPath keyPath of the value
      */
-    mutating public func setValue(val: AnyObject, forKeyPath keyPath: String) {
+    mutating public func setValue(val: Any, forKeyPath keyPath: String) {
         var keys = keyPath.componentsSeparatedByString(".")
         guard let first = keys.first as? Key else { print("Unable to use string as key on type: \(Key.self)"); return }
         keys.removeAtIndex(0)

--- a/Sources/Gloss/Dictionary.swift
+++ b/Sources/Gloss/Dictionary.swift
@@ -38,4 +38,54 @@ extension Dictionary {
         }
     }
     
+    /**
+     Creates a nested dictionary from the keyPath 
+     components separated with '.' and set the value
+     
+     :parameter: val     value to set
+     :parameter: keyPath keyPath of the value
+     */
+    mutating public func setValue(val: AnyObject, forKeyPath keyPath: String) {
+        var keys = keyPath.componentsSeparatedByString(".")
+        guard let first = keys.first as? Key else { print("Unable to use string as key on type: \(Key.self)"); return }
+        keys.removeAtIndex(0)
+        if keys.isEmpty, let settable = val as? Value {
+            self[first] = settable
+        } else {
+            let rejoined = keys.joinWithSeparator(".")
+            var subdict: [NSObject : AnyObject] = [:]
+            if let sub = self[first] as? [NSObject : AnyObject] {
+                subdict = sub
+            }
+            subdict.setValue(val, forKeyPath: rejoined)
+            if let settable = subdict as? Value {
+                self[first] = settable
+            } else {
+                print("Unable to set value: \(subdict) to dictionary of type: \(self.dynamicType)")
+            }
+        }
+        
+    }
+    
+    
+    /**
+     Parse the nested dictionary from the keyPath 
+     components separated with '.' and get the value
+     
+     :parameter: keyPath keyPath with seperator '.'
+     
+     :returns: value from the nested dictionary
+     */
+    public func valueForKeyPath(keyPath: String) -> AnyObject? {
+        var keys = keyPath.componentsSeparatedByString(".")
+        guard let first = keys.first as? Key else { print("Unable to use string as key on type: \(Key.self)"); return nil }
+        guard let value = self[first] as? AnyObject else { return nil }
+        keys.removeAtIndex(0)
+        if !keys.isEmpty, let subDict = value as? [NSObject : AnyObject] {
+            let rejoined = keys.joinWithSeparator(".")
+            return subDict.valueForKeyPath(rejoined)
+        }
+        return value
+    }
+    
 }

--- a/Sources/Gloss/Encoder.swift
+++ b/Sources/Gloss/Encoder.swift
@@ -44,7 +44,9 @@ public struct Encoder {
             property in
             
             if let property = property as? AnyObject {
-                return [key : property]
+                var json: JSON = [:]
+                json.setValue(property, forKeyPath: key)
+                return json
             }
             
             return nil

--- a/Sources/Gloss/Encoder.swift
+++ b/Sources/Gloss/Encoder.swift
@@ -44,9 +44,7 @@ public struct Encoder {
             property in
             
             if let property = property as? AnyObject {
-                var json: JSON = [:]
-                json.setValue(property, forKeyPath: key)
-                return json
+                return [key: property]
             }
             
             return nil

--- a/Sources/GlossTests/KeyPathTests.swift
+++ b/Sources/GlossTests/KeyPathTests.swift
@@ -11,13 +11,18 @@ import XCTest
 
 class KeyPathTests: XCTestCase {
     
-    var nestedKeyPathParams: JSON { return [ "keyPath" : [
-        "id": "1",
-        "args": [
-            "name":"foo",
-            "email":"bar"
+    var nestedKeyPathParams: JSON { return
+        [
+            "keyPath" : [
+                "id": "1",
+                "args": [
+                    "name":"foo",
+                    "email":"bar",
+                    "flag" : true
+                ]
+            ]
         ]
-        ] ] }
+    }
     var nestedKeyPath: NestedKeyPath!
     
     override func setUp() {
@@ -36,14 +41,14 @@ class KeyPathTests: XCTestCase {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct results.
         
-        XCTAssert(nestedKeyPath.keyPath?.id == "1" && nestedKeyPath.keyPath?.name == "foo" && nestedKeyPath.keyPath?.email == "bar", "Passed")
+        XCTAssert(nestedKeyPath.keyPath?.id == "1" && nestedKeyPath.keyPath?.name == "foo" && nestedKeyPath.keyPath?.email == "bar" && nestedKeyPath.flag == true, "Passed")
     }
     
     func testNestedKeyPathToJSON() {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct results.
         
-        XCTAssert((nestedKeyPath?.toJSON())! == ["keyPath" : ["id": "1", "args": ["name":"foo", "email":"bar"]]], "Passed")
+        XCTAssert((nestedKeyPath?.toJSON())! == ["keyPath" : ["id": "1", "args": ["name":"foo", "email":"bar", "flag" : true]]], "Passed")
     }
     
     func testPerformanceExample() {
@@ -61,14 +66,17 @@ extension KeyPathTests {
     struct NestedKeyPath: Glossy {
         
         var keyPath: KeyPath?
+        var flag: Bool
         
         init?(json: JSON) {
             self.keyPath = "keyPath" <~~ json
+            self.flag = "keyPath.args.flag" <~~ json ?? false
         }
         
         func toJSON() -> JSON? {
             return jsonify([
-                "keyPath" ~~> self.keyPath
+                "keyPath" ~~> self.keyPath,
+                "keyPath.args.flag" ~~> self.flag
                 ])
         }
         

--- a/Sources/GlossTests/KeyPathTests.swift
+++ b/Sources/GlossTests/KeyPathTests.swift
@@ -1,0 +1,99 @@
+//
+//  KeyPathTests.swift
+//  Gloss
+//
+//  Created by Rahul Katariya on 01/02/16.
+//  Copyright © 2016 Harlan Kellaway. All rights reserved.
+//
+
+import XCTest
+@testable import Gloss
+
+class KeyPathTests: XCTestCase {
+    
+    var nestedKeyPathParams: JSON { return [ "keyPath" : [
+        "id": "1",
+        "args": [
+            "name":"foo",
+            "email":"bar"
+        ]
+        ] ] }
+    var nestedKeyPath: NestedKeyPath!
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+        
+        nestedKeyPath = NestedKeyPath(json: nestedKeyPathParams)
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testNestedKeyPathFromJSON() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        
+        XCTAssert(nestedKeyPath.keyPath?.id == "1" && nestedKeyPath.keyPath?.name == "foo" && nestedKeyPath.keyPath?.email == "bar", "Passed")
+    }
+    
+    func testNestedKeyPathToJSON() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        
+        XCTAssert((nestedKeyPath?.toJSON())! == ["keyPath" : ["id": "1", "args": ["name":"foo", "email":"bar"]]], "Passed")
+    }
+    
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measureBlock {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+    
+}
+
+extension KeyPathTests {
+    
+    struct NestedKeyPath: Glossy {
+        
+        var keyPath: KeyPath?
+        
+        init?(json: JSON) {
+            self.keyPath = "keyPath" <~~ json
+        }
+        
+        func toJSON() -> JSON? {
+            return jsonify([
+                "keyPath" ~~> self.keyPath
+                ])
+        }
+        
+    }
+    
+    struct KeyPath: Glossy {
+        
+        var id: String?
+        var name: String?
+        var email: String?
+        
+        init?(json: JSON) {
+            self.id = "id" <~~ json
+            self.name = "args.name" <~~ json
+            self.email = "args.email" <~~ json
+        }
+        
+        func toJSON() -> JSON? {
+            return jsonify([
+                "id" ~~> self.id,
+                "args.name" ~~> self.name,
+                "args.email" ~~> self.email
+                ])
+        }
+        
+    }
+    
+}


### PR DESCRIPTION
I have not tested this much but this will allow us to use keyPaths when needed.

    struct Person: Glossy {
        
        let id: String?
        let name: String?
        
        // MARK: - Deserialization
        
        init?(json: JSON) {
            self.id = "args.id" <~~ json
            self.name = "args.name" <~~ json
        }
        
        // MARK: - Serialization
        
        func toJSON() -> JSON? {
            return jsonify([
                "args.id" ~~> self.id,
                "args.login" ~~> self.name
                ])
        }
        
    }