### PR TITLE
Add functions and operators to serialize and deserialize dictionaries

### DIFF
--- a/Sources/Gloss/Decoder.swift
+++ b/Sources/Gloss/Decoder.swift
@@ -175,6 +175,31 @@ public struct Decoder {
     }
     
     /**
+     Returns function to decode JSON to dictionary of
+     objects that conform to the Glossy protocol
+     
+     :parameter: key JSON key used to set value
+     
+     :returns: Function decoding JSON to an optional dictionary
+     */
+    public static func decodeDecodableDictionary<T:Decodable>(key:String) -> JSON -> [String:T]? {
+        return {
+            json in
+            
+            guard let dict = json[key] as? [String:JSON] else {
+                return nil
+            }
+            
+            return dict.flatMap { (key, value) in
+                guard let decoded = T(json: value) else {
+                    return nil
+                }
+                return (key, decoded)
+            }
+        }
+    }
+
+    /**
     Returns function to decode JSON to enum array
     of enum values
     

--- a/Sources/Gloss/Dictionary.swift
+++ b/Sources/Gloss/Dictionary.swift
@@ -38,4 +38,24 @@ extension Dictionary {
         }
     }
     
+    /**
+    Creates a dictionary from a list of elements, this allows us to map, flatMap
+     and filter dictionaries.
+    
+    :parameter: elements to add to the new dictionary
+    */
+    init(elements:[Element]) {
+        self.init()
+        
+        for (key, value) in elements {
+            self[key] = value
+        }
+    }
+    
+    func flatMap<KeyPrime : Hashable, ValuePrime>(transform: (Key, Value) throws -> (KeyPrime, ValuePrime)?) rethrows -> [KeyPrime : ValuePrime] {
+        return Dictionary<KeyPrime,ValuePrime>(elements: try flatMap({ (key, value) in
+            return try transform(key, value)
+        }))
+    }
 }
+

--- a/Sources/Gloss/Encoder.swift
+++ b/Sources/Gloss/Encoder.swift
@@ -193,6 +193,31 @@ public struct Encoder {
     }
     
     /**
+     Returns function to encode a [String:Encodable] into JSON
+     for objects the conform to the Encodable protocol
+     
+     :parameter: key Key used to create JSON property
+     
+     :returns: Function encoding dictionary to optional JSON
+     */
+    public static func encodeEncodableDictionary<T: Encodable>(key: String) -> [String:T]? -> JSON? {
+        return {
+            dict in
+            
+            guard let dict = dict else {
+                return nil
+            }
+            
+            return dict.flatMap { (key, value) in
+                guard let json = value.toJSON() else {
+                    return nil
+                }
+                return (key, json)
+            }
+        }
+    }
+
+    /**
     Returns function to encode array as JSON
     of enum raw values
     

--- a/Sources/Gloss/Operators.swift
+++ b/Sources/Gloss/Operators.swift
@@ -83,6 +83,13 @@ public func <~~ (key: String, json: JSON) -> [NSURL]? {
     return Decoder.decodeURLArray(key)(json)
 }
 
+/**
+ Convenience operator for decoding JSON to Dictionary of String, Decodable objects
+ */
+public func <~~ <T: Decodable>(key: String, json: JSON) -> [String:T]? {
+    return Decoder.decodeDecodableDictionary(key)(json)
+}
+
 // MARK: - Operator ~~> (Encode)
 
 /**
@@ -137,4 +144,11 @@ Convenience operator for encoding array of enum values to JSON
 */
 public func ~~> <T: RawRepresentable>(key: String, property: [T]?) -> JSON? {
     return Encoder.encodeEnumArray(key)(property)
+}
+
+/**
+ Convenience operator for encoding dictionary of Encodable objects to JSON
+ */
+public func ~~> <T: Encodable>(key: String, property: [String:T]?) -> JSON? {
+    return Encoder.encodeEncodableDictionary(key)(property)
 }


### PR DESCRIPTION
Changes allow you to use <~~ and ~~> to serialize dictionaries of serializable objects:

`
{
...
"colors":{
  "red":{"red":255, "green":0, "blue":0},
  "purple":{"red":255, "green":0, "blue:255}
}
}
`

can be serialized using:

`
let colors : [String:Color]

init?(json:JSON) {
    ...
    colors = "colors" <~~ json
    ...
}
`

obviously assuming an appropriate declaration of Color as Decodable.  Also works in reverse to serialize `[String:Encodable]`

