### PR TITLE
Replace Self requirement by function generics

### DIFF
--- a/GlossExample/GlossExample/ViewController.swift
+++ b/GlossExample/GlossExample/ViewController.swift
@@ -60,7 +60,7 @@ class ViewController: UIViewController {
         print("JSON: \(repo.toJSON())")
         print("")
         
-        guard let repos = Repo.modelsFromJSONArray([repoJSON, repoJSON, repoJSON]) else
+        guard let repos: [Repo] = Repo.modelsFromJSONArray([repoJSON, repoJSON, repoJSON]) else
         {
             print("Issue deserializing model array")
             

--- a/GlossExample/GlossExampleTests/GlossTests.swift
+++ b/GlossExample/GlossExampleTests/GlossTests.swift
@@ -109,9 +109,9 @@ class GlossTests: XCTestCase {
     }
     
     func testModelsFromJSONArrayProducesValidModels() {
-        let result = TestModel.modelsFromJSONArray(testJSONArray!)
-        let model1: TestModel = result![0]
-        let model2: TestModel = result![1]
+        let result: [TestModel] = TestModel.modelsFromJSONArray(testJSONArray!)!
+        let model1: TestModel = result[0]
+        let model2: TestModel = result[1]
         
         XCTAssertTrue((model1.bool == true), "Model created from JSON should have correct property values")
         XCTAssertTrue((model1.boolArray! == [true, false, true]), "Model created from JSON should have correct property values")
@@ -170,9 +170,9 @@ class GlossTests: XCTestCase {
     func testModelsFromJSONArrayOnlyIncludesValidModels() {
         testJSONArray![0].removeValueForKey("bool")
         
-        let result = TestModel.modelsFromJSONArray(testJSONArray!)
+        let result: [TestModel] = TestModel.modelsFromJSONArray(testJSONArray!)!
         
-        XCTAssertTrue(result!.count == 1, "Model array from JSON array should only include valid models")
+        XCTAssertTrue(result.count == 1, "Model array from JSON array should only include valid models")
     }
     
     func testJSONArrayFromModelsProducesValidJSON() {
@@ -264,9 +264,9 @@ class GlossTests: XCTestCase {
         invalidJSON.removeValueForKey("bool")
         var jsonArray = testJSONArray!
         jsonArray.append(invalidJSON)
-        let result = TestModel.modelsFromJSONArray(jsonArray)
+        let result: [TestModel] = TestModel.modelsFromJSONArray(jsonArray)!
         
-        XCTAssertTrue(result!.count == 2, "Model array from JSON array should only include valid models")
+        XCTAssertTrue(result.count == 2, "Model array from JSON array should only include valid models")
     }
     
     func testJsonifyTurnsJSONOptionalArrayToSingleJSONOptional() {

--- a/Sources/Gloss/Gloss.swift
+++ b/Sources/Gloss/Gloss.swift
@@ -41,46 +41,47 @@ public protocol Glossy: Decodable, Encodable { }
 Enables an object to be decoded from JSON
 */
 public protocol Decodable {
-    
+
     /**
-    Returns new instance created from provided JSON
-    
-    :parameter: json JSON representation of object
-    */
+     Returns new instance created from provided JSON
+
+     :parameter: json JSON representation of object
+     */
     init?(json: JSON)
-    
+
     /**
-    Returns array of new instances created from provided JSON array
-    
-    :parameter: jsonArray Array of JSON representations of object
-    */
-    static func modelsFromJSONArray(jsonArray: [JSON]) -> [Self]?
-    
+     Returns array of new instances created from provided JSON array
+
+     :parameter: jsonArray Array of JSON representations of object
+     */
+    static func modelsFromJSONArray<T: Decodable>(jsonArray: [JSON]) -> [T]?
+
 }
 
 /**
-Extension of Decodable protocol with default implementations
-*/
+ Extension of Decodable protocol with default implementations
+ */
 public extension Decodable {
-    
+
     /**
-    Returns array of new instances created from provided JSON array
-    
-    Note: The returned array will have only models that successfully
-    decoded
-    
-    :parameter: jsonArray Array of JSON representations of object
-    */
-    static func modelsFromJSONArray(jsonArray: [JSON]) -> [Self]? {
-        var models: [Self] = []
-        
+     Returns array of new instances created from provided JSON array
+
+     Note: The returned array will have only models that successfully
+     decoded
+
+     :parameter: jsonArray Array of JSON representations of object
+     */
+    static func modelsFromJSONArray<T: Decodable>(jsonArray: [JSON]) -> [T]? {
+
+        var models: [T] = []
+
         for json in jsonArray {
-            let model = Self(json: json)
+            let model = T(json: json)
             if let model = model {
                 models.append(model)
             }
         }
-        
+
         return models
     }
     

--- a/Sources/Gloss/Gloss.swift
+++ b/Sources/Gloss/Gloss.swift
@@ -102,7 +102,7 @@ public protocol Encodable {
     
     :parameter: models Array of models to be encoded as JSON
     */
-    static func toJSONArray(models:[Self]) -> [JSON]?
+    static func toJSONArray<T: Encodable>(models:[T]) -> [JSON]?
 }
 
 /**
@@ -118,7 +118,7 @@ public extension Encodable {
     
     :parameter: models Array of models to be encoded as JSON
     */
-    static func toJSONArray(models:[Self]) -> [JSON]? {
+    static func toJSONArray<T: Encodable>(models:[T]) -> [JSON]? {
         var jsonArray: [JSON] = []
         
         for model in models {


### PR DESCRIPTION
The Self requirement in the Decodable protocol doesn't allow the use of classes that are not final. This replacement with function generics fixes this issue.