### PR TITLE
Escape strings before creation of NSURL

### DIFF
--- a/Sources/Decoder.swift
+++ b/Sources/Decoder.swift
@@ -144,8 +144,9 @@ public struct Decoder {
         return {
             json in
             
-            if let urlString = json.valueForKeyPath(key, withDelimiter: keyPathDelimiter) as? String {
-                return NSURL(string: urlString)
+            if let urlString = json.valueForKeyPath(key, withDelimiter: keyPathDelimiter) as? String,
+                encodedString = urlString.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLQueryAllowedCharacterSet()) {
+                    return NSURL(string: encodedString)
             }
             
             return nil


### PR DESCRIPTION
Ran into this issue when converting a legacy project from SwiftyJSON to Gloss.

SwiftyJSON has a line of code that escaped strings before creating NSURLs.Thus, URLs that used to be parsed properly were not read properly after conversion. Adding this extra step solved the problem for me.