### PR TITLE
fix encoding issue with nested object->dictionary translations

### DIFF
--- a/GlossExample/GlossExampleTests/EncoderTests.swift
+++ b/GlossExample/GlossExampleTests/EncoderTests.swift
@@ -110,11 +110,11 @@ class EncoderTests: XCTestCase {
     }
     
     func testEncodeEncodableDictionary() {
-        let dictionary = ["dictionary" : testNestedModel1!]
-        let result: JSON? = Encoder.encodeEncodableDictionary("dictionary")(dictionary)
-        
-        XCTAssertTrue(result!["dictionary"]!["id"] == 1, "Encode Dictionary should return correct value")
-        XCTAssertTrue(result!["dictionary"]!["name"] == "nestedModel1", "Encode Dictionary should return correct value")
+        let result: JSON? = Encoder.encodeEncodableDictionary("dictionary")(["model1":testNestedModel1!])
+     
+        let dictionary = result!["dictionary"] as! [String:[String:AnyObject]]
+        XCTAssertTrue(dictionary["model1"]!["id"] as! Int == 1, "Encode Dictionary should return correct value")
+        XCTAssertTrue(dictionary["model1"]!["name"] as! String == "nestedModel1", "Encode Dictionary should return correct value")
     }
 
     func testEncodeString() {

--- a/GlossExample/GlossExampleTests/FlowObjectToJSON.swift
+++ b/GlossExample/GlossExampleTests/FlowObjectToJSON.swift
@@ -116,10 +116,10 @@ class ObjectToJSONFlowTests: XCTestCase {
         XCTAssertTrue((result!["url"] as! String == "http://github.com"), "JSON created from model should have correct values")
         XCTAssertTrue(((result!["urlArray"] as! [NSURL]).map { url in url.absoluteString } == ["http://github.com", "http://github.com"]), "JSON created from model should have correct values")
         
-        let dictionary = result!["otherModel"] as! [String : AnyObject]
+        let otherModel = (result!["dictionary"] as! [String:JSON])["otherModel"]!
         
-        XCTAssertTrue(dictionary["id"] as! Int == 1, "Encode encodable dictionary should return correct value")
-        XCTAssertTrue(dictionary["name"] as! String == "nestedModel1", "Encode encodable dictionary should return correct value")
+        XCTAssertTrue(otherModel["id"] as! Int == 1, "Encode encodable dictionary should return correct value")
+        XCTAssertTrue(otherModel["name"] as! String == "nestedModel1", "Encode encodable dictionary should return correct value")
         
         let nestedModel: JSON = result!["nestedModel"] as! JSON
         

--- a/GlossExample/GlossExampleTests/OperatorTests.swift
+++ b/GlossExample/GlossExampleTests/OperatorTests.swift
@@ -272,8 +272,11 @@ class OperatorTests: XCTestCase {
         let result: JSON? = "dictionary" ~~> dictionary
         let encoderResult: JSON? = Encoder.encodeEncodableDictionary("dictionary")(dictionary)
         
-        XCTAssertTrue((result!["otherModel"]!["id"]) == (encoderResult!["otherModel"]!["id"]), "~~> for generic value should return same as Encoder.encodeEncodableDictionary for dictionary")
-        XCTAssertTrue((result!["otherModel"]!["name"]) == (encoderResult!["otherModel"]!["name"]), "~~> for generic value should return same as Encoder.encodeEncodableDictionary for dictionary")
+        let dict = (result!["dictionary"] as! JSON)["otherModel"] as! JSON
+        let encDict = (encoderResult!["dictionary"] as! JSON)["otherModel"] as! JSON
+        
+        XCTAssertTrue(dict["id"] as! Int == encDict["id"] as! Int, "~~> for [String:Encodable] value should return same as Encoder.encodeEncodableDictionary for dictionary")
+        XCTAssertTrue(dict["name"] as! String == encDict["name"] as! String, "~~> for [String:Encodable] value should return same as Encoder.encodeEncodableDictionary for dictionary")
     }
     
     func testEncodeOperatorGenericReturnsEncoderEncodeForString() {

--- a/Sources/Encoder.swift
+++ b/Sources/Encoder.swift
@@ -208,13 +208,15 @@ public struct Encoder {
                 return nil
             }
             
-            return dictionary.flatMap { (key, value) in
+            let encoded : [String:JSON] = dictionary.flatMap { (key, value) in
                 guard let json = value.toJSON() else {
                     return nil
                 }
                 
                 return (key, json)
             }
+            
+            return [key : encoded]
         }
     }
 


### PR DESCRIPTION
Fix an issue that resulted in the top level object->dictionary translation being lost.