### PR TITLE
Fix Date Parsing for non-Gregorian Calendars

### DIFF
--- a/Sources/Gloss.swift
+++ b/Sources/Gloss.swift
@@ -78,6 +78,7 @@ public func GlossDateFormatterISO8601() -> NSDateFormatter {
     }
     
     dateFormatterISO8601 = NSDateFormatter()
+    // WORKAROUND to ignore device configuration regarding AM/PM http://openradar.appspot.com/radar?id=1110403
     dateFormatterISO8601!.locale = NSLocale(localeIdentifier: "en_US_POSIX")
     dateFormatterISO8601!.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
     

--- a/Sources/Gloss.swift
+++ b/Sources/Gloss.swift
@@ -81,7 +81,12 @@ public func GlossDateFormatterISO8601() -> NSDateFormatter {
     // WORKAROUND to ignore device configuration regarding AM/PM http://openradar.appspot.com/radar?id=1110403
     dateFormatterISO8601!.locale = NSLocale(localeIdentifier: "en_US_POSIX")
     dateFormatterISO8601!.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
-    
+
+    // translate to Gregorian calendar if other calendar is selected in system settings
+    let gregorian = NSCalendar(calendarIdentifier: NSCalendarIdentifierGregorian)!
+    gregorian.timeZone = NSTimeZone(abbreviation: "GMT")!
+    dateFormatterISO8601!.calendar = gregorian
+
     return dateFormatterISO8601!
 }
 


### PR DESCRIPTION
If non-Gregorian calendar is selected in system settings, the date parsing fails. This workaround fixes that.