### PR TITLE
Can't remove from keys when keys is empty.

### DIFF
--- a/Sources/ExtensionDictionary.swift
+++ b/Sources/ExtensionDictionary.swift
@@ -50,11 +50,9 @@ public extension Dictionary {
             return nil
         }
         
-        keys.removeAtIndex(0)
-        
         if !keys.isEmpty, let subDict = value as? JSON {
+            keys.removeAtIndex(0)
             let rejoined = keys.joinWithSeparator(delimiter)
-            
             return subDict.valueForKeyPath(rejoined, withDelimiter: delimiter)
         }
         


### PR DESCRIPTION
This causes a crash when compiled with optimizations, however works fine when compiled without optimizations - hence the test suite didn't catch it.