### PR TITLE
Fixed link to blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ The particular word "gloss" was chosen as it evokes both being lightweight and a
 
 Gloss was created by [Harlan Kellaway](http://harlankellaway.com).
 
-Inspiration was gathered from other great JSON parsing libraries like [Argo](https://github.com/thoughtbot/Argo). Read more about why Gloss was made [here](http://harlankellaway.com/blog/2015/08/16/introducing-gloss-json-parsing-swift/).
+Inspiration was gathered from other great JSON parsing libraries like [Argo](https://github.com/thoughtbot/Argo). Read more about why Gloss was made [here](http://harlankellaway.com/blog/2015/08/16/introducing-gloss-json-parsing-swift).
 
 Special thanks to all [contributors](https://github.com/hkellaway/Gloss/contributors)! :sparkling_heart:
 


### PR DESCRIPTION
'Page not found' if the link ends with slash