### PR TITLE
Gloss support for Swift 2.3 and iOS 10 SDK beta 1

### DIFF
--- a/Gloss.xcodeproj/project.pbxproj
+++ b/Gloss.xcodeproj/project.pbxproj
@@ -343,17 +343,19 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Harlan Kellaway";
 				TargetAttributes = {
 					2FA4CE991C947E3000EB8AB8 = {
 						CreatedOnToolsVersion = 7.3;
+						LastSwiftMigration = 0800;
 					};
 					A04168E61C0DF69900269A6A = {
 						CreatedOnToolsVersion = 7.1.1;
 					};
 					DC39BF601B8A7AD200088CE0 = {
 						CreatedOnToolsVersion = 7.0;
+						LastSwiftMigration = 0800;
 					};
 					DC683ADA1C2C615D0035EAC3 = {
 						CreatedOnToolsVersion = 7.1;
@@ -518,6 +520,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.harlankellaway.GlossTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -529,6 +532,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.harlankellaway.GlossTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -570,6 +575,7 @@
 				PRODUCT_NAME = Gloss;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -680,6 +686,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -698,6 +705,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.harlankellaway.Gloss;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -736,6 +745,7 @@
 				PRODUCT_NAME = Gloss;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
@@ -783,6 +793,7 @@
 				PRODUCT_NAME = Gloss;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
 		};
@@ -796,6 +807,7 @@
 				2FA4CEA31C947E3000EB8AB8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		A04168FC1C0DF69A00269A6A /* Build configuration list for PBXNativeTarget "Gloss tvOS" */ = {
 			isa = XCConfigurationList;

--- a/Gloss.xcodeproj/xcshareddata/xcschemes/Gloss tvOS.xcscheme
+++ b/Gloss.xcodeproj/xcshareddata/xcschemes/Gloss tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Gloss.xcodeproj/xcshareddata/xcschemes/Gloss watchOS.xcscheme
+++ b/Gloss.xcodeproj/xcshareddata/xcschemes/Gloss watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Gloss.xcodeproj/xcshareddata/xcschemes/Gloss.xcscheme
+++ b/Gloss.xcodeproj/xcshareddata/xcschemes/Gloss.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -32,7 +32,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DC39BF6A1B8A7AD200088CE0"
+               BlueprintIdentifier = "2FA4CE991C947E3000EB8AB8"
                BuildableName = "GlossTests.xctest"
                BlueprintName = "GlossTests"
                ReferencedContainer = "container:Gloss.xcodeproj">

--- a/Gloss.xcodeproj/xcshareddata/xcschemes/GlossMacOSX.xcscheme
+++ b/Gloss.xcodeproj/xcshareddata/xcschemes/GlossMacOSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Gloss.xcodeproj/xcshareddata/xcschemes/GlossTests.xcscheme
+++ b/Gloss.xcodeproj/xcshareddata/xcschemes/GlossTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/GlossExample/GlossExample.xcodeproj/project.pbxproj
+++ b/GlossExample/GlossExample.xcodeproj/project.pbxproj
@@ -21,7 +21,7 @@
 /* Begin PBXFileReference section */
 		1CF68443A5AEBB8235A16A54 /* Pods-GlossExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GlossExample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-GlossExample/Pods-GlossExample.debug.xcconfig"; sourceTree = "<group>"; };
 		371978450C13B8BC0B320144 /* Pods_GlossExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GlossExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		DC08B5AC1B76B3ED0098D6C8 /* GlossExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = GlossExample.app; path = "/Users/harlankellaway/Documents/Projects/Other/Gloss/GlossExample/build/Debug-iphoneos/GlossExample.app"; sourceTree = "<absolute>"; };
+		9C12015D1D12D723004FD72C /* GlossExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GlossExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC08B5B01B76B3ED0098D6C8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DC08B5B11B76B3ED0098D6C8 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DC08B5B31B76B3ED0098D6C8 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -71,6 +71,7 @@
 				DC08B5AE1B76B3ED0098D6C8 /* GlossExample */,
 				36A8572C924B8EDFB71DDE70 /* Pods */,
 				63509F10EB2766219388D381 /* Frameworks */,
+				9C12015D1D12D723004FD72C /* GlossExample.app */,
 			);
 			sourceTree = "<group>";
 		};
@@ -113,12 +114,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DC08B5CB1B76B3ED0098D6C8 /* Build configuration list for PBXNativeTarget "GlossExample" */;
 			buildPhases = (
-				C037FA1074C68EBAE2B6D9B9 /* Check Pods Manifest.lock */,
+				C037FA1074C68EBAE2B6D9B9 /* [CP] Check Pods Manifest.lock */,
 				DC08B5A81B76B3ED0098D6C8 /* Sources */,
 				DC08B5A91B76B3ED0098D6C8 /* Frameworks */,
 				DC08B5AA1B76B3ED0098D6C8 /* Resources */,
-				D19E0ACE63372003AA0ABBD4 /* Embed Pods Frameworks */,
-				835BD57B6BD17E8965AC408C /* Copy Pods Resources */,
+				D19E0ACE63372003AA0ABBD4 /* [CP] Embed Pods Frameworks */,
+				835BD57B6BD17E8965AC408C /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -126,7 +127,7 @@
 			);
 			name = GlossExample;
 			productName = GlossExample;
-			productReference = DC08B5AC1B76B3ED0098D6C8 /* GlossExample.app */;
+			productReference = 9C12015D1D12D723004FD72C /* GlossExample.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -137,11 +138,12 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Harlan Kellaway";
 				TargetAttributes = {
 					DC08B5AB1B76B3ED0098D6C8 = {
 						CreatedOnToolsVersion = 6.4;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -178,14 +180,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		835BD57B6BD17E8965AC408C /* Copy Pods Resources */ = {
+		835BD57B6BD17E8965AC408C /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -193,14 +195,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-GlossExample/Pods-GlossExample-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		C037FA1074C68EBAE2B6D9B9 /* Check Pods Manifest.lock */ = {
+		C037FA1074C68EBAE2B6D9B9 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -208,14 +210,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		D19E0ACE63372003AA0ABBD4 /* Embed Pods Frameworks */ = {
+		D19E0ACE63372003AA0ABBD4 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -345,11 +347,13 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1CF68443A5AEBB8235A16A54 /* Pods-GlossExample.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = GlossExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.harlankellaway.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -357,11 +361,14 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = ED8E6DA407D0AE26300C907D /* Pods-GlossExample.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = GlossExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.harlankellaway.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/GlossExample/GlossExample.xcodeproj/xcshareddata/xcschemes/GlossExample.xcscheme
+++ b/GlossExample/GlossExample.xcodeproj/xcshareddata/xcschemes/GlossExample.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/GlossTests/EncoderTests.swift
+++ b/GlossTests/EncoderTests.swift
@@ -47,7 +47,7 @@ class EncoderTests: XCTestCase {
     }
     
     func testInvalidValue() {
-        let notAnyObject: NSURL? = NSURL()
+        let notAnyObject: NSURL? = NSURL(string: "garbage {}\';")
         let result: JSON? = Encoder.encode("invalid")(notAnyObject)
         
         XCTAssertTrue((result == nil), "Encode should return nil for invalid value");
@@ -290,7 +290,7 @@ class EncoderTests: XCTestCase {
         
         let test = result!["urlArray"] as! [NSURL]
         
-        XCTAssertTrue(test.map { url in url.absoluteString } == ["http://github.com", "http://github.com"], "Encode NSURL array should return correct value")
+        XCTAssertTrue(test.map { url in url.absoluteString! } == ["http://github.com", "http://github.com"], "Encode NSURL array should return correct value")
     }
 
 }

--- a/GlossTests/FlowObjectCreationTests.swift
+++ b/GlossTests/FlowObjectCreationTests.swift
@@ -84,7 +84,7 @@ class FlowObjectCreationTests: XCTestCase {
 		XCTAssertTrue(result.uInt64Array! == [300000000, 9223372036854775808, 18446744073709551615], "Model created from JSON should have correct property values")
 		XCTAssertTrue((result.dateISO8601Array!.map { date in date.timeIntervalSince1970 }) == [1439071033, 1439071033], "Model created from JSON should have correct property values")
         XCTAssertTrue((result.url?.absoluteString == "http://github.com"), "Model created from JSON should have correct property values")
-        XCTAssertTrue((result.urlArray?.map { url in url.absoluteString })! == ["http://github.com", "http://github.com", "http://github.com"], "Model created from JSON should have correct property values")
+        XCTAssertTrue((result.urlArray?.map { url in url.absoluteString! })! == ["http://github.com", "http://github.com", "http://github.com"], "Model created from JSON should have correct property values")
         
         XCTAssertTrue((result.nestedModel?.id == 123), "Model created from JSON should have correct property values")
         XCTAssertTrue((result.nestedModel?.name == "nestedModel1"), "Model created from JSON should have correct property values")

--- a/GlossTests/FlowObjectToJSON.swift
+++ b/GlossTests/FlowObjectToJSON.swift
@@ -134,7 +134,7 @@ class ObjectToJSONFlowTests: XCTestCase {
         XCTAssertTrue(resultDate8601Array == [1439071033, 1439071033], "JSON created from model should have correct values")
         
         XCTAssertTrue((result!["url"] as! String == "http://github.com"), "JSON created from model should have correct values")
-        XCTAssertTrue(((result!["urlArray"] as! [NSURL]).map { url in url.absoluteString } == ["http://github.com", "http://github.com"]), "JSON created from model should have correct values")
+        XCTAssertTrue(((result!["urlArray"] as! [NSURL]).map { url in url.absoluteString! } == ["http://github.com", "http://github.com"]), "JSON created from model should have correct values")
         
         let otherModel = (result!["dictionary"] as! [String : JSON])["otherModel"]!
         

--- a/Sources/Encoder.swift
+++ b/Sources/Encoder.swift
@@ -455,8 +455,8 @@ public struct Encoder {
         return {
             url in
             
-            if let url = url {
-                return [key : url.absoluteString]
+            if let absoluteURLString = url?.absoluteString {
+                return [key : absoluteURLString]
             }
             
             return nil


### PR DESCRIPTION
Deprecates #172 

@hkellaway I was also thinking that changes in `Sources/Encoder.swift` could be also submitted to master. It would then work on both iOS 9 and 10 SDK.

I can make another PR for that, if you feel this is worth it.