### PR TITLE
Updated de/encode array functions to return nil if failure

### DIFF
--- a/GlossTests/DecoderTests.swift
+++ b/GlossTests/DecoderTests.swift
@@ -101,6 +101,13 @@ class DecoderTests: XCTestCase {
         XCTAssertTrue((element3 == true), "Decode Bool array should return correct value")
     }
     
+    func testDecodeBoolArrayReturnsNilIfJSONInvalid() {
+        let invalidJSON = [ "array" : ["1", "2", "3"] ]
+        let result: [Bool]? = Decoder.decode("array")(invalidJSON)
+        
+        XCTAssertNil(result, "Decode bool array should return nil if JSON is invalid")
+    }
+    
     func testDecodeInt() {
         let result: Int? = Decoder.decode("integer")(testJSON!)
         
@@ -116,6 +123,13 @@ class DecoderTests: XCTestCase {
         XCTAssertTrue((element1 == 1), "Decode Int array should return correct value")
         XCTAssertTrue((element2 == 2), "Decode Int array should return correct value")
         XCTAssertTrue((element3 == 3), "Decode Int array should return correct value")
+    }
+    
+    func testDecodeIntArrayReturnsNilIfJSONInvalid() {
+        let invalidJSON = [ "array" : ["1", "2", "3"] ]
+        let result: [Int]? = Decoder.decode("array")(invalidJSON)
+        
+        XCTAssertNil(result, "Decode int array should return nil if JSON is invalid")
     }
     
     func testDecodeFloat() {
@@ -135,6 +149,13 @@ class DecoderTests: XCTestCase {
         XCTAssertTrue((element3 == 3.0), "Decode Float array should return correct value")
     }
     
+    func testDecodeFloatArrayReturnsNilIfJSONInvalid() {
+        let invalidJSON = [ "array" : ["1", "2", "3"] ]
+        let result: [Float]? = Decoder.decode("array")(invalidJSON)
+        
+        XCTAssertNil(result, "Decode float array should return nil if JSON is invalid")
+    }
+    
     func testDecodeDouble() {
         let result: Double? = Decoder.decode("double")(testJSON!)
         
@@ -150,6 +171,13 @@ class DecoderTests: XCTestCase {
         XCTAssertTrue((element1 == 4.0), "Decode Double array should return correct value")
         XCTAssertTrue((element2 == 5.0), "Decode Double array should return correct value")
         XCTAssertTrue((element3 == 6.0), "Decode Double array should return correct value")
+    }
+    
+    func testDecodeDoubleArrayReturnsNilIfJSONInvalid() {
+        let invalidJSON = [ "array" : ["1", "2", "3"] ]
+        let result: [Double]? = Decoder.decode("array")(invalidJSON)
+        
+        XCTAssertNil(result, "Decode double array should return nil if JSON is invalid")
     }
     
     func testDecodeDictionary() {
@@ -196,6 +224,13 @@ class DecoderTests: XCTestCase {
         XCTAssertTrue((element3 == "jkl"), "Decode String array should return correct value")
     }
     
+    func testDecodeStringArrayReturnsNilIfJSONInvalid() {
+        let invalidJSON = [ "array" : [1, 2, 3] ]
+        let result: [String]? = Decoder.decode("array")(invalidJSON)
+        
+        XCTAssertNil(result, "Decode string array should return nil if JSON is invalid")
+    }
+    
     func testDecodeNestedModel() {
         let result: TestNestedModel? = Decoder.decodeDecodable("nestedModel")(testJSON!)
         
@@ -218,6 +253,13 @@ class DecoderTests: XCTestCase {
         XCTAssertTrue((element1 == TestModel.EnumValue.A), "Decode enum value array should return correct value")
         XCTAssertTrue((element2 == TestModel.EnumValue.B), "Decode enum value array should return correct value")
         XCTAssertTrue((element3 == TestModel.EnumValue.C), "Decode enum value array should return correct value")
+    }
+    
+    func testDecodeEnumArrayReturnsNilIfJSONInvalid() {
+        let invalidJSON = [ "array" : ["1", "2", "3"] ]
+        let result: [TestModel.EnumValue]? = Decoder.decodeEnumArray("array")(invalidJSON)
+        
+        XCTAssertNil(result, "Decode enum array should return nil if JSON is invalid")
     }
     
     func testDecodeDate() {
@@ -278,6 +320,13 @@ class DecoderTests: XCTestCase {
         XCTAssertTrue((nanosecond2/1000000 == 599), "Decode NSDate array should return correct value")
     }
     
+    func testDecodeDateArrayReturnsNilIfJSONInvalid() {
+        let invalidJSON = [ "array" : ["1", "2", "3"] ]
+        let result: [NSDate]? = Decoder.decodeDateArray("array", dateFormatter: TestModel.dateFormatter)(invalidJSON)
+        
+        XCTAssertNil(result, "Decode date array should return nil if JSON is invalid")
+    }
+    
     func testDecodeDateISO8601() {
         let result: NSDate? = Decoder.decodeDateISO8601("dateISO8601")(testJSON!)
         
@@ -296,6 +345,13 @@ class DecoderTests: XCTestCase {
         XCTAssertTrue(timeInterval2 == 1439071033, "Decode NSDate array should return correct value")
     }
 
+    func testDecodeDateISO8601ArrayArrayReturnsNilIfJSONInvalid() {
+        let invalidJSON = [ "array" : ["1", "2", "3"] ]
+        let result: [NSDate]? = Decoder.decodeDateISO8601Array("array")(invalidJSON)
+        
+        XCTAssertNil(result, "Decode NSDate array should return nil if JSON is invalid")
+    }
+    
     func testDecodeInt32() {
         let result: Int32? = Decoder.decodeInt32("int32")(testJSON!)
         
@@ -306,6 +362,13 @@ class DecoderTests: XCTestCase {
         let result: [Int32]? = Decoder.decodeInt32Array("int32Array")(testJSON!)
         
         XCTAssertTrue((result! == [100000000, -2147483648, 2147483647]), "Decode Int32 array should return correct value")
+    }
+    
+    func testDecodeInt32ArrayReturnsNilIfJSONInvalid() {
+        let invalidJSON = [ "array" : ["1", "2", "3"] ]
+        let result: [Int32]? = Decoder.decodeInt32Array("array")(invalidJSON)
+        
+        XCTAssertNil(result, "Decode Int32 array should return nil if JSON is invalid")
     }
 
 	func testDecodeUInt32() {
@@ -319,6 +382,13 @@ class DecoderTests: XCTestCase {
 
 		XCTAssertTrue((result! == [100000000, 2147483648, 4294967295]), "Decode UInt32 array should return correct value")
 	}
+    
+    func testDecodeUInt32ArrayReturnsNilIfJSONInvalid() {
+        let invalidJSON = [ "array" : ["1", "2", "3"] ]
+        let result: [UInt32]? = Decoder.decodeUInt32Array("array")(invalidJSON)
+        
+        XCTAssertNil(result, "Decode UInt32 array should return nil if JSON is invalid")
+    }
 
     func testDecodeInt64() {
         let result: Int64? = Decoder.decodeInt64("int64")(testJSON!)
@@ -330,6 +400,13 @@ class DecoderTests: XCTestCase {
         let result: [Int64]? = Decoder.decodeInt64Array("int64Array")(testJSON!)
         
         XCTAssertTrue((result! == [300000000, -9223372036854775808, 9223372036854775807]), "Decode Int64 array should return correct value")
+    }
+    
+    func testDecodeInt64ArrayReturnsNilIfJSONInvalid() {
+        let invalidJSON = [ "array" : ["1", "2", "3"] ]
+        let result: [Int64]? = Decoder.decodeInt64Array("array")(invalidJSON)
+        
+        XCTAssertNil(result, "Decode Int64 array should return nil if JSON is invalid")
     }
 
 	func testDecodeUInt64() {
@@ -343,6 +420,13 @@ class DecoderTests: XCTestCase {
 
 		XCTAssertTrue((result! == [300000000, 9223372036854775808, 18446744073709551615]), "Decode UInt64 array should return correct value")
 	}
+    
+    func testDecodeUInt64ArrayReturnsNilIfJSONInvalid() {
+        let invalidJSON = [ "array" : ["1", "2", "3"] ]
+        let result: [UInt64]? = Decoder.decodeUInt64Array("array")(invalidJSON)
+        
+        XCTAssertNil(result, "Decode UInt64 array should return nil if JSON is invalid")
+    }
 
     func testDecodeURL() {
         let result: NSURL? = Decoder.decodeURL("url")(testJSON!)
@@ -359,6 +443,13 @@ class DecoderTests: XCTestCase {
         XCTAssertTrue((element1.absoluteString == "http://github.com"), "Decode NSURL array should return correct value")
         XCTAssertTrue((element2.absoluteString == "http://github.com"), "Decode NSURL array should return correct value")
         XCTAssertTrue((element3.absoluteString == "http://github.com"), "Decode NSURL array should return correct value")
+    }
+    
+    func testDecodeURLArrayReturnsNilIfJSONInvalid() {
+        let invalidJSON = [ "array" : [1, 1, 1] ]
+        let result: [NSURL]? = Decoder.decodeURLArray("array")(invalidJSON)
+        
+        XCTAssertNil(result, "Decode url array should return nil if JSON is invalid")
     }
     
 }

--- a/GlossTests/EncoderTests.swift
+++ b/GlossTests/EncoderTests.swift
@@ -67,6 +67,13 @@ class EncoderTests: XCTestCase {
         XCTAssertTrue((result!["boolArray"] as! [Bool] == [true, false, true]), "Encode Bool array should return correct value")
     }
     
+    func testEncodeBoolLArrayReturnsNilIfModelInvalid() {
+        let invalidModel = ["1", "2", "3"]
+        let result: JSON? = Encoder.encode("array")(invalidModel)
+        
+        XCTAssertNil(result?["array"] as? [Bool], "Encode bool array should return nil if model is invalid")
+    }
+    
     func testEncodeInt() {
         let integer: Int? = 1
         let result: JSON? = Encoder.encode("integer")(integer)
@@ -81,6 +88,13 @@ class EncoderTests: XCTestCase {
         XCTAssertTrue((result!["integerArray"] as! [Int] == [1, 2, 3]), "Encode Int array should return correct value")
     }
 
+    func testEncodeIntLArrayReturnsNilIfModelInvalid() {
+        let invalidModel = ["1", "2", "3"]
+        let result: JSON? = Encoder.encode("array")(invalidModel)
+        
+        XCTAssertNil(result?["array"] as? [Int], "Encode int array should return nil if model is invalid")
+    }
+    
     func testEncodeFloat() {
         let float: Float? = 1.0
         let result: JSON? = Encoder.encode("float")(float)
@@ -95,6 +109,13 @@ class EncoderTests: XCTestCase {
         XCTAssertTrue((result!["floatArray"] as! [Float] == [1.0, 2.0, 3.0]), "Encode Float array should return correct value")
     }
     
+    func testEncodeFloatLArrayReturnsNilIfModelInvalid() {
+        let invalidModel = ["1", "2", "3"]
+        let result: JSON? = Encoder.encode("array")(invalidModel)
+        
+        XCTAssertNil(result?["array"] as? [Float], "Encode float array should return nil if model is invalid")
+    }
+    
     func testEncodeDouble() {
         let double: Double? = 4.0
         let result: JSON? = Encoder.encode("double")(double)
@@ -107,6 +128,13 @@ class EncoderTests: XCTestCase {
         let result: JSON? = Encoder.encode("doubleArray")(doubleArray)
         
         XCTAssertTrue((result!["doubleArray"] as! [Double] == [4.0, 5.0, 6.0]), "Encode Double array should return correct value")
+    }
+    
+    func testEncodeDoubleLArrayReturnsNilIfModelInvalid() {
+        let invalidModel = ["1", "2", "3"]
+        let result: JSON? = Encoder.encode("array")(invalidModel)
+        
+        XCTAssertNil(result?["array"] as? [Double], "Encode double array should return nil if model is invalid")
     }
     
     func testEncodeEncodableDictionary() {
@@ -141,6 +169,13 @@ class EncoderTests: XCTestCase {
         let result: JSON? = Encoder.encode("stringArray")(stringArray)
         
         XCTAssertTrue((result!["stringArray"] as! [String] == ["def", "ghi", "jkl"]), "String array should return correct value")
+    }
+    
+    func testEncodeStringLArrayReturnsNilIfModelInvalid() {
+        let invalidModel = [1, 2, 3]
+        let result: JSON? = Encoder.encode("array")(invalidModel)
+        
+        XCTAssertNil(result?["array"] as? [String], "Encode string array should return nil if model is invalid")
     }
     
     func testEncodeNestedModel() {
@@ -179,6 +214,13 @@ class EncoderTests: XCTestCase {
         XCTAssertTrue((result!["enumValueArray"] as! [TestModel.EnumValue.RawValue] == ["A", "B", "C"]), "Encode enum value array should return correct value")
     }
     
+    func testEncodeEnumArrayReturnsNilIfModelInvalid() {
+        let invalidModel = ["1", "2", "3"]
+        let result: JSON? = Encoder.encode("array")(invalidModel)
+        
+        XCTAssertNil(result?["array"] as? [TestModel.EnumValue], "Encode enum array should return nil if model is invalid")
+    }
+    
     func testEncodeDate() {
         let date: NSDate? = TestModel.dateFormatter.dateFromString("2015-08-16T20:51:46.600Z")
         let result: JSON? = Encoder.encodeDate("date", dateFormatter: TestModel.dateFormatter)(date)
@@ -192,6 +234,13 @@ class EncoderTests: XCTestCase {
         let result: JSON? = Encoder.encodeDateArray("dateArray", dateFormatter: TestModel.dateFormatter)(dateArray)
         
         XCTAssertTrue(result!["dateArray"] as! [String] == ["2015-08-16T20:51:46.600Z", "2015-08-16T20:51:46.600Z"], "Encode NSDate array should return correct value")
+    }
+    
+    func testEncodeDateArrayReturnsNilIfModelInvalid() {
+        let invalidModel = [NSDate(timeIntervalSince1970: 1), NSDate(timeIntervalSince1970: 2), NSDate(timeIntervalSince1970: 3)]
+        let result: JSON? = Encoder.encodeDateArray("array", dateFormatter: TestModel.dateFormatter)(invalidModel)
+        
+        XCTAssertNil(result?["array"] as? [NSDate], "Encode date array should return nil if model is invalid")
     }
     
     func testEncodeDateISO8601() {
@@ -219,6 +268,13 @@ class EncoderTests: XCTestCase {
         
         XCTAssertTrue(resultDate1?.timeIntervalSince1970 == 1439071033, "Encode ISO8601 NSDate array should return correct value")
         XCTAssertTrue(resultDate2?.timeIntervalSince1970 == 1439071033, "Encode ISO8601 NSDate array should return correct value")
+    }
+    
+    func testEncodeDateISO8601ArrayReturnsNilIfModelInvalid() {
+        let invalidModel = [NSDate(timeIntervalSince1970: 1), NSDate(timeIntervalSince1970: 2), NSDate(timeIntervalSince1970: 3)]
+        let result: JSON? = Encoder.encodeDateISO8601Array("array")(invalidModel)
+        
+        XCTAssertNil(result?["array"] as? [NSDate], "Encode date array should return nil if model is invalid")
     }
     
     func testEncodeInt32() {
@@ -291,6 +347,13 @@ class EncoderTests: XCTestCase {
         let test = result!["urlArray"] as! [NSURL]
         
         XCTAssertTrue(test.map { url in url.absoluteString } == ["http://github.com", "http://github.com"], "Encode NSURL array should return correct value")
+    }
+    
+    func testEncodeURLArrayReturnsNilIfModelInvalid() {
+        let invalidModel = ["1", "2", "3"]
+        let result: JSON? = Encoder.encodeArray("array")(invalidModel)
+        
+        XCTAssertNil(result?["array"] as? [NSURL], "Encode url array should return nil if model is invalid")
     }
 
 }

--- a/Sources/Decoder.swift
+++ b/Sources/Decoder.swift
@@ -88,9 +88,11 @@ public struct Decoder {
                 var dates: [NSDate] = []
                 
                 for dateString in dateStrings {
-                    if let date = dateFormatter.dateFromString(dateString) {
-                        dates.append(date)
+                    guard let date = dateFormatter.dateFromString(dateString) else {
+                        return nil
                     }
+                    
+                    dates.append(date)
                 }
                 
                 return dates
@@ -161,9 +163,11 @@ public struct Decoder {
                 var models: [T] = []
                 
                 for subJSON in jsonArray {
-                    if let model = T(json: subJSON) {
-                        models.append(model)
+                    guard let model = T(json: subJSON) else {
+                        return nil
                     }
+                    
+                    models.append(model)
                 }
                 
                 return models
@@ -265,9 +269,11 @@ public struct Decoder {
                 var enumValues: [T] = []
                 
                 for rawValue in rawValues {
-                    if let enumValue = T(rawValue: rawValue) {
-                        enumValues.append(enumValue)
+                    guard let enumValue = T(rawValue: rawValue) else {
+                        return nil
                     }
+                    
+                    enumValues.append(enumValue)
                 }
                 
                 return enumValues
@@ -482,9 +488,11 @@ public struct Decoder {
                 var urls: [NSURL] = []
                 
                 for urlString in urlStrings {
-                    if let url = NSURL(string: urlString) {
-                        urls.append(url)
+                    guard let url = NSURL(string: urlString) else {
+                        return nil
                     }
+                    
+                    urls.append(url)
                 }
                 
                 return urls

--- a/Sources/Encoder.swift
+++ b/Sources/Encoder.swift
@@ -172,9 +172,11 @@ public struct Encoder {
                 var encodedArray: [JSON] = []
                 
                 for model in array {
-                    if let json = model.toJSON() {
-                        encodedArray.append(json)
+                    guard let json = model.toJSON() else {
+                        return nil
                     }
+                    
+                    encodedArray.append(json)
                 }
                 
                 return [key : encodedArray]


### PR DESCRIPTION
Update made for consistency with other semantics. See Issue #189 