### PR TITLE
Update Swift syntax for Xcode 8 Beta 6.

### DIFF
--- a/GlossTests/DecoderTests.swift
+++ b/GlossTests/DecoderTests.swift
@@ -36,8 +36,8 @@ class DecoderTests: XCTestCase {
     override func setUp() {
         super.setUp()
         
-        var testJSONPath: NSString = Bundle(for: self.dynamicType).pathForResource("TestModel", ofType: "json")!
-        var testJSONData: Data = try! Data(contentsOf: URL(fileURLWithPath: testJSONPath as String))
+        var testJSONPath: String = Bundle(for: type(of: self)).path(forResource: "TestModel", ofType: "json")!
+        var testJSONData: Data = try! Data(contentsOf: URL(fileURLWithPath: testJSONPath))
         
         do {
             try testJSON = JSONSerialization.jsonObject(with: testJSONData, options: JSONSerialization.ReadingOptions(rawValue: 0)) as? JSON
@@ -45,7 +45,7 @@ class DecoderTests: XCTestCase {
             print(error)
         }
         
-        testJSONPath  = Bundle(for: self.dynamicType).pathForResource("TestFailableModelValid", ofType: "json")!
+        testJSONPath = Bundle(for: type(of: self)).path(forResource: "TestFailableModelValid", ofType: "json")!
         testJSONData = try! Data(contentsOf: URL(fileURLWithPath: testJSONPath as String))
         
         do {
@@ -54,7 +54,7 @@ class DecoderTests: XCTestCase {
             print(error)
         }
         
-        testJSONPath  = Bundle(for: self.dynamicType).pathForResource("TestFailableModelInvalid", ofType: "json")!
+        testJSONPath = Bundle(for: type(of: self)).path(forResource: "TestFailableModelInvalid", ofType: "json")!
         testJSONData = try! Data(contentsOf: URL(fileURLWithPath: testJSONPath as String))
         
         do {
@@ -223,13 +223,13 @@ class DecoderTests: XCTestCase {
     func testDecodeDate() {
         let result: Date? = Decoder.decodeDate("date", dateFormatter: TestModel.dateFormatter)(testJSON!)
         
-        let year: Int = Calendar.current().components(Calendar.Unit.year, from: result!).year!
-        let month: Int = Calendar.current().components(Calendar.Unit.month, from: result!).month!
-        let day: Int = Calendar.current().components(Calendar.Unit.day, from: result!).day!
-        let hour: Int = Calendar.current().components(Calendar.Unit.hour, from: result!).hour!
-        let minute: Int = Calendar.current().components(Calendar.Unit.minute, from: result!).minute!
-        let second: Int = Calendar.current().components(Calendar.Unit.second, from: result!).second!
-        let nanosecond: Int = Calendar.current().components(Calendar.Unit.nanosecond, from: result!).nanosecond!
+        let year: Int = Calendar.current.component(.year, from: result!)
+        let month: Int = Calendar.current.component(.month, from: result!)
+        let day: Int = Calendar.current.component(.day, from: result!)
+        let hour: Int = Calendar.current.component(.hour, from: result!)
+        let minute: Int = Calendar.current.component(.minute, from: result!)
+        let second: Int = Calendar.current.component(.second, from: result!)
+        let nanosecond: Int = Calendar.current.component(.nanosecond, from: result!)
         
         XCTAssertTrue((year == 2015), "Decode NSDate should return correct value")
         XCTAssertTrue((month == 8), "Decode NSDate should return correct value")
@@ -245,21 +245,21 @@ class DecoderTests: XCTestCase {
         let element1: Date = result![0]
         let element2: Date = result![1]
         
-        let year1: Int = Calendar.current().components(Calendar.Unit.year, from: element1).year!
-        let month1: Int = Calendar.current().components(Calendar.Unit.month, from: element1).month!
-        let day1: Int = Calendar.current().components(Calendar.Unit.day, from: element1).day!
-        let hour1: Int = Calendar.current().components(Calendar.Unit.hour, from: element1).hour!
-        let minute1: Int = Calendar.current().components(Calendar.Unit.minute, from: element1).minute!
-        let second1: Int = Calendar.current().components(Calendar.Unit.second, from: element1).second!
-        let nanosecond1: Int = Calendar.current().components(Calendar.Unit.nanosecond, from: element1).nanosecond!
+        let year1: Int = Calendar.current.component(.year, from: element1)
+        let month1: Int = Calendar.current.component(.month, from: element1)
+        let day1: Int = Calendar.current.component(.day, from: element1)
+        let hour1: Int = Calendar.current.component(.hour, from: element1)
+        let minute1: Int = Calendar.current.component(.minute, from: element1)
+        let second1: Int = Calendar.current.component(.second, from: element1)
+        let nanosecond1: Int = Calendar.current.component(.nanosecond, from: element1)
         
-        let year2: Int = Calendar.current().components(Calendar.Unit.year, from: element2).year!
-        let month2: Int = Calendar.current().components(Calendar.Unit.month, from: element2).month!
-        let day2: Int = Calendar.current().components(Calendar.Unit.day, from: element2).day!
-        let hour2: Int = Calendar.current().components(Calendar.Unit.hour, from: element2).hour!
-        let minute2: Int = Calendar.current().components(Calendar.Unit.minute, from: element2).minute!
-        let second2: Int = Calendar.current().components(Calendar.Unit.second, from: element2).second!
-        let nanosecond2: Int = Calendar.current().components(Calendar.Unit.nanosecond, from: element2).nanosecond!
+        let year2: Int = Calendar.current.component(.year, from: element2)
+        let month2: Int = Calendar.current.component(.month, from: element2)
+        let day2: Int = Calendar.current.component(.day, from: element2)
+        let hour2: Int = Calendar.current.component(.hour, from: element2)
+        let minute2: Int = Calendar.current.component(.minute, from: element2)
+        let second2: Int = Calendar.current.component(.second, from: element2)
+        let nanosecond2: Int = Calendar.current.component(.nanosecond, from: element2)
         
         XCTAssertTrue((year1 == 2015), "Decode NSDate array should return correct value")
         XCTAssertTrue((month1 == 8), "Decode NSDate array should return correct value")

--- a/GlossTests/EncoderTests.swift
+++ b/GlossTests/EncoderTests.swift
@@ -199,7 +199,7 @@ class EncoderTests: XCTestCase {
         let result: JSON? = Encoder.encodeDateISO8601("dateISO8601")(dateISO8601!)
         
         let dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale(localeIdentifier: "en_US_POSIX")
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
         let resultDate = dateFormatter.date(from: result!["dateISO8601"] as! String)
         
@@ -212,10 +212,12 @@ class EncoderTests: XCTestCase {
         let result: JSON? = Encoder.encodeDateISO8601Array("dateISO8601Array")(dateISO8601Array!)
         
         let dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale(localeIdentifier: "en_US_POSIX")
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
-        let resultDate1 = dateFormatter.date(from: result!["dateISO8601Array"]![0] as! String)
-        let resultDate2 = dateFormatter.date(from: result!["dateISO8601Array"]![1] as! String)
+        
+        let resultArray: [String] = result!["dateISO8601Array"] as! [String]
+        let resultDate1 = dateFormatter.date(from: resultArray[0])
+        let resultDate2 = dateFormatter.date(from: resultArray[1])
         
         XCTAssertTrue(resultDate1?.timeIntervalSince1970 == 1439071033, "Encode ISO8601 NSDate array should return correct value")
         XCTAssertTrue(resultDate2?.timeIntervalSince1970 == 1439071033, "Encode ISO8601 NSDate array should return correct value")
@@ -290,7 +292,7 @@ class EncoderTests: XCTestCase {
         
         let test = result!["urlArray"] as! [URL]
         
-        XCTAssertTrue(test.map { url in url.absoluteString! } == ["http://github.com", "http://github.com"], "Encode NSURL array should return correct value")
+        XCTAssertTrue(test.map { url in url.absoluteString } == ["http://github.com", "http://github.com"], "Encode NSURL array should return correct value")
     }
 
 }

--- a/GlossTests/FlowObjectCreationTests.swift
+++ b/GlossTests/FlowObjectCreationTests.swift
@@ -34,7 +34,7 @@ class FlowObjectCreationTests: XCTestCase {
     override func setUp() {
         super.setUp()
         
-        let testJSONPath: NSString = Bundle(for: self.dynamicType).pathForResource("TestModel", ofType: "json")!
+        let testJSONPath: String = Bundle(for: type(of: self)).path(forResource: "TestModel", ofType: "json")!
         let testJSONData: Data = try! Data(contentsOf: URL(fileURLWithPath: testJSONPath as String))
         
         do {
@@ -84,7 +84,7 @@ class FlowObjectCreationTests: XCTestCase {
 		XCTAssertTrue(result.uInt64Array! == [300000000, 9223372036854775808, 18446744073709551615], "Model created from JSON should have correct property values")
 		XCTAssertTrue((result.dateISO8601Array!.map { date in date.timeIntervalSince1970 }) == [1439071033, 1439071033], "Model created from JSON should have correct property values")
         XCTAssertTrue((result.url?.absoluteString == "http://github.com"), "Model created from JSON should have correct property values")
-        XCTAssertTrue((result.urlArray?.map { url in url.absoluteString! })! == ["http://github.com", "http://github.com", "http://github.com"], "Model created from JSON should have correct property values")
+        XCTAssertTrue((result.urlArray?.map { url in url.absoluteString })! == ["http://github.com", "http://github.com", "http://github.com"], "Model created from JSON should have correct property values")
         
         XCTAssertTrue((result.nestedModel?.id == 123), "Model created from JSON should have correct property values")
         XCTAssertTrue((result.nestedModel?.name == "nestedModel1"), "Model created from JSON should have correct property values")

--- a/GlossTests/FlowObjectToJSON.swift
+++ b/GlossTests/FlowObjectToJSON.swift
@@ -122,7 +122,7 @@ class ObjectToJSONFlowTests: XCTestCase {
         
         let dateISO8601 = result!["dateISO8601"] as! String
         let dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale(localeIdentifier: "en_US_POSIX")
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
         let resultDate = dateFormatter.date(from: dateISO8601)
         
@@ -134,7 +134,7 @@ class ObjectToJSONFlowTests: XCTestCase {
         XCTAssertTrue(resultDate8601Array == [1439071033, 1439071033], "JSON created from model should have correct values")
         
         XCTAssertTrue((result!["url"] as! String == "http://github.com"), "JSON created from model should have correct values")
-        XCTAssertTrue(((result!["urlArray"] as! [URL]).map { url in url.absoluteString! } == ["http://github.com", "http://github.com"]), "JSON created from model should have correct values")
+        XCTAssertTrue(((result!["urlArray"] as! [URL]).map { url in url.absoluteString } == ["http://github.com", "http://github.com"]), "JSON created from model should have correct values")
         
         let otherModel = (result!["dictionary"] as! [String : JSON])["otherModel"]!
         

--- a/GlossTests/GlossTests.swift
+++ b/GlossTests/GlossTests.swift
@@ -37,8 +37,8 @@ class GlossTests: XCTestCase {
         super.setUp()
         
         var testJSON: JSON? = [:]
-        let testJSONPath: NSString = Bundle(for: self.dynamicType).pathForResource("TestModel", ofType: "json")!
-        let testJSONData: Data = try! Data(contentsOf: URL(fileURLWithPath: testJSONPath as String))
+        let testJSONPath: String = Bundle(for: type(of: self)).path(forResource: "TestModel", ofType: "json")!
+        let testJSONData: Data = try! Data(contentsOf: URL(fileURLWithPath: testJSONPath))
         
         do {
             try testJSON = JSONSerialization.jsonObject(with: testJSONData, options:JSONSerialization.ReadingOptions(rawValue: 0)) as? JSON
@@ -95,7 +95,7 @@ class GlossTests: XCTestCase {
     func testDateFormatterISO8601HasCorrectLocale() {
         let dateFormatterISO8601 = GlossDateFormatterISO8601
         
-        XCTAssertTrue(dateFormatterISO8601.locale.localeIdentifier == "en_US_POSIX", "Date formatter ISO8601 should have correct locale.")
+        XCTAssertTrue(dateFormatterISO8601.locale.identifier == "en_US_POSIX", "Date formatter ISO8601 should have correct locale.")
     }
     
     func testDateFormatterISO8601HasCorrectDateFormat() {
@@ -106,9 +106,9 @@ class GlossTests: XCTestCase {
     
     func testDateFormatterISO8601ForcesGregorianCalendar() {
         let dateFormatterISO8601 = GlossDateFormatterISO8601
-        
-        XCTAssertTrue(dateFormatterISO8601.calendar.calendarIdentifier == Calendar.Identifier.gregorian, "Date formatter ISO8601 should force use of Gregorian calendar.")
-         XCTAssertTrue(dateFormatterISO8601.calendar.timeZone.abbreviation == "GMT", "Date formatter ISO8601 Gregorian calendar should use GMT timezone.")
+
+        XCTAssertTrue(dateFormatterISO8601.calendar.identifier == Calendar.Identifier.gregorian, "Date formatter ISO8601 should force use of Gregorian calendar.")
+        XCTAssertTrue(dateFormatterISO8601.calendar.timeZone.abbreviation() == "GMT", "Date formatter ISO8601 Gregorian calendar should use GMT timezone.")
     }
     
     func testJsonifyTurnsArrayOfJsonDictsToSingleJsonDict() {
@@ -187,7 +187,7 @@ class GlossTests: XCTestCase {
     }
     
     func testModelsFromJSONArrayReturnsNilIfDecodingFails() {
-        testJSONArray![0].removeValueForKey("bool")
+        testJSONArray![0].removeValue(forKey: "bool")
         
         let result = [TestModel].fromJSONArray(testJSONArray!)
 
@@ -215,7 +215,7 @@ class GlossTests: XCTestCase {
         
         let dateISO8601 = json1["dateISO8601"] as! String
         let dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale(localeIdentifier: "en_US_POSIX")
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
         let resultDate = dateFormatter.date(from: dateISO8601)
         
@@ -254,7 +254,7 @@ class GlossTests: XCTestCase {
         
         let date2ISO8601 = json2["dateISO8601"] as! String
         let date2Formatter = DateFormatter()
-        date2Formatter.locale = Locale(localeIdentifier: "en_US_POSIX")
+        date2Formatter.locale = Locale(identifier: "en_US_POSIX")
         date2Formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
         let resultDate2 = dateFormatter.date(from: date2ISO8601)
         

--- a/GlossTests/KeyPathTests.swift
+++ b/GlossTests/KeyPathTests.swift
@@ -55,7 +55,16 @@ class KeyPathTests: XCTestCase {
     }
     
     func testNestedKeyPathToJSON() {
-        XCTAssert((nestedKeyPathModel?.toJSON())! == ["keyPath" : ["id": 1, "args": ["name":"foo", "url": "http://url.com", "flag" : true]]], "Should encode with nested key path")
+        let nestedKeyPathJson = nestedKeyPathModel!.toJSON()! as! [String: [String: Any]]
+        let referenceJson = ["keyPath" : ["id": 1 as AnyObject, "args": ["name":"foo", "url": "http://url.com", "flag" : true]]]
+        
+        XCTAssert(nestedKeyPathJson["keyPath"]!["id"] as! Int == referenceJson["keyPath"]!["id"] as! Int, "Should encode with nested key path")
+        
+        let args = nestedKeyPathJson["keyPath"]!["args"] as! JSON
+        let referenceArgs = referenceJson["keyPath"]!["args"] as! JSON
+        XCTAssert(args["name"] as! String == referenceArgs["name"] as! String, "Should encode with nested key path")
+        XCTAssert(args["url"] as! String == referenceArgs["url"] as! String, "Should encode with nested key path")
+        XCTAssert(args["flag"] as! Bool == referenceArgs["flag"] as! Bool, "Should encode with nested key path")
     }
     
     func testNonDefaultKeyPathDecode() {
@@ -65,8 +74,9 @@ class KeyPathTests: XCTestCase {
     
     func testNonDefaultKeyPathEncode() {
         let result = keyPathModelWithCustomDelimiter.toJSON()
-        let id = result!["nested"]!["id"]
-        let url = result!["nested"]!["url"]
+        let nested = result!["nested"] as! JSON
+        let id = nested["id"] as? Int
+        let url = nested["url"] as? String
         
         XCTAssertTrue(id == 123, "Should encode model with custom key path delimiter")
         XCTAssertTrue(url == "http://url.com", "Should encode model with custom key path delimiter")

--- a/GlossTests/OperatorTests.swift
+++ b/GlossTests/OperatorTests.swift
@@ -36,8 +36,8 @@ class OperatorTests: XCTestCase {
     override func setUp() {
         super.setUp()
         
-        let testJSONPath: NSString = Bundle(for: self.dynamicType).pathForResource("TestModel", ofType: "json")!
-        let testJSONData: Data = try! Data(contentsOf: URL(fileURLWithPath: testJSONPath as String))
+        let testJSONPath = Bundle(for: type(of: self)).path(forResource: "TestModel", ofType: "json")!
+        let testJSONData: Data = try! Data(contentsOf: URL(fileURLWithPath: testJSONPath))
         
         do {
             try testJSON = JSONSerialization.jsonObject(with: testJSONData, options: JSONSerialization.ReadingOptions(rawValue: 0)) as? JSON

--- a/Sources/Encoder.swift
+++ b/Sources/Encoder.swift
@@ -41,7 +41,7 @@ public struct Encoder {
         return {
             property in
             
-            if let property = property as? AnyObject {
+            if let property = property {
                 return [key : property]
             }
             
@@ -60,7 +60,7 @@ public struct Encoder {
         return {
             array in
             
-            if let array = array as? AnyObject {
+            if let array = array {
                 return [key : array]
             }
             
@@ -252,7 +252,7 @@ public struct Encoder {
             enumValue in
             
             if let enumValue = enumValue {
-                return [key : enumValue.rawValue as! AnyObject]
+                return [key : enumValue.rawValue]
             }
             
             return nil
@@ -277,7 +277,7 @@ public struct Encoder {
                     rawValues.append(enumValue.rawValue)
                 }
                 
-                return [key : rawValues as! AnyObject]
+                return [key : rawValues]
             }
             
             return nil

--- a/Sources/ExtensionDictionary.swift
+++ b/Sources/ExtensionDictionary.swift
@@ -50,7 +50,7 @@ public extension Dictionary {
             return nil
         }
         
-        guard let value = self[first] as? AnyObject else {
+        guard let value = self[first] else {
             return nil
         }
         
@@ -60,7 +60,7 @@ public extension Dictionary {
             return subDict.value(forKeyPath: rejoined, withDelimiter: delimiter)
         }
         
-        return value
+        return value as AnyObject
     }
     
     // MARK: - Internal functions
@@ -146,7 +146,7 @@ public extension Dictionary {
             if let settable = subdict as? Value {
                 self[first] = settable
             } else {
-                print("[Gloss] Unable to set value: \(subdict) to dictionary of type: \(self.dynamicType)")
+                print("[Gloss] Unable to set value: \(subdict) to dictionary of type: \(type(of: self))")
             }
         }
         

--- a/Sources/Gloss.swift
+++ b/Sources/Gloss.swift
@@ -27,7 +27,7 @@ import Foundation
 
 // MARK: - Types
 
-public typealias JSON = [String : AnyObject]
+public typealias JSON = [String : Any]
 
 // MARK: - Protocols
 

--- a/Sources/Operators.swift
+++ b/Sources/Operators.swift
@@ -27,10 +27,15 @@ import Foundation
 
 // MARK: - Operator <~~ (Decode)
 
+precedencegroup DecodingPrecedence {
+    associativity: left
+    higherThan: CastingPrecedence
+}
+
 /**
 Decode custom operator.
 */
-infix operator <~~ { associativity left precedence 150 }
+infix operator <~~ : DecodingPrecedence
 
 /**
 Convenience operator for decoding JSON to generic value.
@@ -238,10 +243,15 @@ public func <~~ (key: String, json: JSON) -> [URL]? {
 
 // MARK: - Operator ~~> (Encode)
 
+precedencegroup EncodingPrecedence {
+    associativity: left
+    higherThan: CastingPrecedence
+}
+
 /**
 Encode custom operator.
 */
-infix operator ~~> { associativity left precedence 150 }
+infix operator ~~> : EncodingPrecedence
 
 /**
 Convenience operator for encoding generic value to JSON


### PR DESCRIPTION
The biggest change was the JSON type changing from `[String: AnyObject]` to `[String: Any]`.
I believe that is the best approach for the change on the way `id` gets imported from Objective-C.

I also had to rewrite `KeyPathTests.testNestedKeyPathToJSON`.