### PR TITLE
Reintroduce Nested Keypaths

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,3 @@
-gem 'cocoapods', '1.1.0.rc.2'
+source 'https://rubygems.org'
+
+gem 'cocoapods', :git => 'https://github.com/CocoaPods/CocoaPods.git', :tag => '1-1-stable'

--- a/Gloss.xcodeproj/project.pbxproj
+++ b/Gloss.xcodeproj/project.pbxproj
@@ -40,6 +40,11 @@
 		2FA4CEC41C947F2600EB8AB8 /* FlowObjectToJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA4CEBC1C947F2600EB8AB8 /* FlowObjectToJSON.swift */; };
 		2FA4CEC51C947F2600EB8AB8 /* GlossTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA4CEBD1C947F2600EB8AB8 /* GlossTests.swift */; };
 		2FA4CEC71C947F2600EB8AB8 /* OperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA4CEBF1C947F2600EB8AB8 /* OperatorTests.swift */; };
+		A40E6F981DB61D330065F079 /* TestNestedKeyPathModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40E6F971DB61D330065F079 /* TestNestedKeyPathModel.swift */; };
+		A40E6F9A1DB61D5C0065F079 /* TestKeyPathModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40E6F991DB61D5C0065F079 /* TestKeyPathModel.swift */; };
+		A40E6F9C1DB61D8A0065F079 /* TestKeyPathModelCustomDelimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40E6F9B1DB61D8A0065F079 /* TestKeyPathModelCustomDelimiter.swift */; };
+		A40E6F9E1DB61F6D0065F079 /* KeyPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40E6F9D1DB61F6D0065F079 /* KeyPathTests.swift */; };
+		A40E6FA01DB62A630065F079 /* Comparators.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40E6F9F1DB62A630065F079 /* Comparators.swift */; };
 		DCD40A601C7A7B11007EE251 /* ExtensionArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD40A5E1C7A7B11007EE251 /* ExtensionArray.swift */; };
 		DCD40A611C7A7B11007EE251 /* ExtensionDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD40A5F1C7A7B11007EE251 /* ExtensionDictionary.swift */; };
 		DCD40A621C7A7C58007EE251 /* ExtensionArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD40A5E1C7A7B11007EE251 /* ExtensionArray.swift */; };
@@ -82,6 +87,11 @@
 		2FA4CEBD1C947F2600EB8AB8 /* GlossTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GlossTests.swift; sourceTree = "<group>"; };
 		2FA4CEBF1C947F2600EB8AB8 /* OperatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperatorTests.swift; sourceTree = "<group>"; };
 		A04168E71C0DF69900269A6A /* Gloss.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Gloss.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A40E6F971DB61D330065F079 /* TestNestedKeyPathModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestNestedKeyPathModel.swift; sourceTree = "<group>"; };
+		A40E6F991DB61D5C0065F079 /* TestKeyPathModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestKeyPathModel.swift; sourceTree = "<group>"; };
+		A40E6F9B1DB61D8A0065F079 /* TestKeyPathModelCustomDelimiter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestKeyPathModelCustomDelimiter.swift; sourceTree = "<group>"; };
+		A40E6F9D1DB61F6D0065F079 /* KeyPathTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyPathTests.swift; sourceTree = "<group>"; };
+		A40E6F9F1DB62A630065F079 /* Comparators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Comparators.swift; path = GlossTests/Comparators.swift; sourceTree = SOURCE_ROOT; };
 		DC39BF611B8A7AD200088CE0 /* Gloss.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Gloss.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC683ADB1C2C615D0035EAC3 /* Gloss.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Gloss.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DCD40A5E1C7A7B11007EE251 /* ExtensionArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ExtensionArray.swift; path = Sources/ExtensionArray.swift; sourceTree = SOURCE_ROOT; };
@@ -140,6 +150,7 @@
 				2FA4CEBD1C947F2600EB8AB8 /* GlossTests.swift */,
 				2FA4CEBF1C947F2600EB8AB8 /* OperatorTests.swift */,
 				2FA4CE9E1C947E3000EB8AB8 /* Info.plist */,
+				A40E6F9D1DB61F6D0065F079 /* KeyPathTests.swift */,
 			);
 			path = GlossTests;
 			sourceTree = "<group>";
@@ -153,6 +164,9 @@
 				2FA4CEAB1C947EC400EB8AB8 /* TestModel.json */,
 				2FA4CEAC1C947EC400EB8AB8 /* TestModel.swift */,
 				2FA4CEAE1C947EC400EB8AB8 /* TestNestedModel.swift */,
+				A40E6F971DB61D330065F079 /* TestNestedKeyPathModel.swift */,
+				A40E6F991DB61D5C0065F079 /* TestKeyPathModel.swift */,
+				A40E6F9B1DB61D8A0065F079 /* TestKeyPathModelCustomDelimiter.swift */,
 			);
 			path = "Test Models";
 			sourceTree = "<group>";
@@ -189,6 +203,7 @@
 				2F3A832C1C66CF3C00ECC4B8 /* Gloss.swift */,
 				2F3A832D1C66CF3C00ECC4B8 /* Info.plist */,
 				2F3A832E1C66CF3C00ECC4B8 /* Operators.swift */,
+				A40E6F9F1DB62A630065F079 /* Comparators.swift */,
 			);
 			path = Gloss;
 			sourceTree = "<group>";
@@ -421,14 +436,19 @@
 			buildActionMask = 2147483647;
 			files = (
 				2FA4CEC31C947F2600EB8AB8 /* FlowObjectCreationTests.swift in Sources */,
+				A40E6F9C1DB61D8A0065F079 /* TestKeyPathModelCustomDelimiter.swift in Sources */,
+				A40E6F9A1DB61D5C0065F079 /* TestKeyPathModel.swift in Sources */,
+				A40E6F981DB61D330065F079 /* TestNestedKeyPathModel.swift in Sources */,
 				2FA4CEC51C947F2600EB8AB8 /* GlossTests.swift in Sources */,
 				2FA4CEB51C947EC400EB8AB8 /* TestModel.swift in Sources */,
 				2FA4CEC41C947F2600EB8AB8 /* FlowObjectToJSON.swift in Sources */,
+				A40E6FA01DB62A630065F079 /* Comparators.swift in Sources */,
 				2FA4CEAF1C947EC400EB8AB8 /* TestFailableModel.swift in Sources */,
 				2FA4CEC21C947F2600EB8AB8 /* EncoderTests.swift in Sources */,
 				2FA4CEB71C947EC400EB8AB8 /* TestNestedModel.swift in Sources */,
 				2FA4CEC01C947F2600EB8AB8 /* DecoderTests.swift in Sources */,
 				2FA4CEC71C947F2600EB8AB8 /* OperatorTests.swift in Sources */,
+				A40E6F9E1DB61F6D0065F079 /* KeyPathTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GlossTests/Comparators.swift
+++ b/GlossTests/Comparators.swift
@@ -1,0 +1,14 @@
+//
+//  Comparators.swift
+//  Gloss
+//
+//  Created by Maciej Kołek on 10/18/16.
+//  Copyright © 2016 Harlan Kellaway. All rights reserved.
+//
+
+import Foundation
+import Gloss
+
+public func ==(lhs: JSON, rhs: JSON ) -> Bool {
+    return NSDictionary(dictionary: lhs).isEqual(to: rhs)
+}

--- a/GlossTests/DecoderTests.swift
+++ b/GlossTests/DecoderTests.swift
@@ -433,7 +433,7 @@ class DecoderTests: XCTestCase {
         
         XCTAssertTrue((result?.absoluteString == "http://github.com"), "Decode URL should return correct value")
     }
-    
+
     func testDecodeURLArray() {
         let result: [URL]? = Decoder.decode(urlArrayForKey: "urlArray")(testJSON!)
         let element1: URL = result![0]
@@ -444,12 +444,35 @@ class DecoderTests: XCTestCase {
         XCTAssertTrue((element2.absoluteString == "http://github.com"), "Decode URL array should return correct value")
         XCTAssertTrue((element3.absoluteString == "http://github.com"), "Decode URL array should return correct value")
     }
-    
+
     func testDecodeURLArrayReturnsNilIfJSONInvalid() {
         let invalidJSON = [ "array" : [1, 1, 1] ]
         let result: [URL]? = Decoder.decode(urlArrayForKey: "array")(invalidJSON as JSON)
-        
+
         XCTAssertNil(result, "Decode url array should return nil if JSON is invalid")
     }
-    
+
+    func testDecodeUUID() {
+        let result: UUID? = Decoder.decode(uuidForKey: "uuid")(testJSON!)
+
+        XCTAssertTrue((result?.uuidString == "964F2FE2-0F78-4C2D-A291-03058C0B98AB"), "Decode UUID should return correct value")
+    }
+
+    func testDecodeUUIDArray() {
+        let result: [UUID]? = Decoder.decode(uuidArrayForKey: "uuidArray")(testJSON!)
+        let element1: UUID = result![0]
+        let element2: UUID = result![1]
+        let element3: UUID = result![2]
+
+        XCTAssertTrue((element1.uuidString == "572099C2-B9AA-42AA-8A25-66E3F3056271"), "Decode UUID array should return correct value")
+        XCTAssertTrue((element2.uuidString == "54DB8DCF-F68D-4B55-A3FC-EB8CF4C36B06"), "Decode UUID array should return correct value")
+        XCTAssertTrue((element3.uuidString == "982CED72-743A-45F8-87CF-278386D32EBF"), "Decode UUID array should return correct value")
+    }
+
+    func testDecodeUUIDArrayReturnsNilIfJSONInvalid() {
+        let invalidJSON = [ "array" : [1, 1, 1] ]
+        let result: [UUID]? = Decoder.decode(uuidArrayForKey: "array")(invalidJSON as JSON)
+
+        XCTAssertNil(result, "Decode UUID array should return nil if JSON is invalid")
+    }
 }

--- a/GlossTests/EncoderTests.swift
+++ b/GlossTests/EncoderTests.swift
@@ -351,12 +351,34 @@ class EncoderTests: XCTestCase {
         
         XCTAssertTrue(test.map { url in url.absoluteString } == ["http://github.com", "http://github.com"], "Encode URL array should return correct value")
     }
-    
+
     func testEncodeURLArrayReturnsNilIfModelInvalid() {
         let invalidModel = ["1", "2", "3"]
         let result: JSON? = Encoder.encode(arrayForKey: "array")(invalidModel)
-        
+
         XCTAssertNil(result?["array"] as? [URL], "Encode url array should return nil if model is invalid")
     }
 
+    func testEncodeUUID() {
+        let uuid: UUID? = UUID(uuidString: "5D8C7570-F700-4CDD-A6F5-A2DBE0D59647")
+        let result: JSON? = Encoder.encode(uuidForKey: "uuid")(uuid)
+
+        XCTAssertTrue((result!["uuid"] as! String == "5D8C7570-F700-4CDD-A6F5-A2DBE0D59647"), "Encode UUID should return correct value")
+    }
+
+    func testEncodeUUIDArray() {
+        let uuids: [UUID]? = [UUID(uuidString: "CC7DA36D-51E5-42A1-BCA3-E9D8E567B051")!, UUID(uuidString: "21F300CB-47F5-4DDF-8C76-9C8D0241FB96")!]
+        let result: JSON? = Encoder.encode(arrayForKey: "uuidArray")(uuids)
+
+        let test = result!["uuidArray"] as! [UUID]
+
+        XCTAssertTrue(test.map { uuid in uuid.uuidString } == ["CC7DA36D-51E5-42A1-BCA3-E9D8E567B051", "21F300CB-47F5-4DDF-8C76-9C8D0241FB96"], "Encode UUID array should return correct value")
+    }
+
+    func testEncodeUUIDArrayReturnsNilIfModelInvalid() {
+        let invalidModel = ["1", "2", "3"]
+        let result: JSON? = Encoder.encode(arrayForKey: "array")(invalidModel)
+
+        XCTAssertNil(result?["array"] as? [UUID], "Encode uuid array should return nil if model is invalid")
+    }
 }

--- a/GlossTests/FlowObjectCreationTests.swift
+++ b/GlossTests/FlowObjectCreationTests.swift
@@ -85,6 +85,9 @@ class FlowObjectCreationTests: XCTestCase {
 		XCTAssertTrue((result.dateISO8601Array!.map { date in date.timeIntervalSince1970 }) == [1439071033, 1439071033], "Model created from JSON should have correct property values")
         XCTAssertTrue((result.url?.absoluteString == "http://github.com"), "Model created from JSON should have correct property values")
         XCTAssertTrue((result.urlArray?.map { url in url.absoluteString })! == ["http://github.com", "http://github.com", "http://github.com"], "Model created from JSON should have correct property values")
+
+        XCTAssertTrue((result.uuid?.uuidString == "964F2FE2-0F78-4C2D-A291-03058C0B98AB"), "Model created from JSON should have correct property values")
+        XCTAssertTrue((result.uuidArray?.map { uuid in uuid.uuidString })! == ["572099C2-B9AA-42AA-8A25-66E3F3056271", "54DB8DCF-F68D-4B55-A3FC-EB8CF4C36B06", "982CED72-743A-45F8-87CF-278386D32EBF"], "Model created from JSON should have correct property values")
         
         XCTAssertTrue((result.nestedModel?.id == 123), "Model created from JSON should have correct property values")
         XCTAssertTrue((result.nestedModel?.name == "nestedModel1"), "Model created from JSON should have correct property values")

--- a/GlossTests/FlowObjectToJSON.swift
+++ b/GlossTests/FlowObjectToJSON.swift
@@ -88,7 +88,9 @@ class ObjectToJSONFlowTests: XCTestCase {
             "int64" : 300000000,
             "int64Array" : [300000000, 300000000, 300000000],
             "url" : "http://github.com",
-            "urlArray" : ["http://github.com", "http://github.com"]
+            "urlArray" : ["http://github.com", "http://github.com"],
+            "uuid" : "964F2FE2-0F78-4C2D-A291-03058C0B98AB",
+            "uuidArray" : ["572099C2-B9AA-42AA-8A25-66E3F3056271", "54DB8DCF-F68D-4B55-A3FC-EB8CF4C36B06", "982CED72-743A-45F8-87CF-278386D32EBF"]
         ]
         
         testModel = TestModel(json: json)
@@ -138,6 +140,9 @@ class ObjectToJSONFlowTests: XCTestCase {
         XCTAssertTrue((result!["url"] as! String == "http://github.com"), "JSON created from model should have correct values")
         XCTAssertTrue(((result!["urlArray"] as! [URL]).map { url in url.absoluteString } == ["http://github.com", "http://github.com"]), "JSON created from model should have correct values")
         
+        XCTAssertTrue((result!["uuid"] as! String == "964F2FE2-0F78-4C2D-A291-03058C0B98AB"), "JSON created from model should have correct values")
+        XCTAssertTrue(((result!["uuidArray"] as! [UUID]).map { uuid in uuid.uuidString } == ["572099C2-B9AA-42AA-8A25-66E3F3056271", "54DB8DCF-F68D-4B55-A3FC-EB8CF4C36B06", "982CED72-743A-45F8-87CF-278386D32EBF"]), "JSON created from model should have correct values")
+
         let otherModel = (result!["dictionary"] as! [String : JSON])["otherModel"]!
         
         XCTAssertTrue(otherModel["id"] as! Int == 1, "Encode encodable dictionary should return correct value")

--- a/GlossTests/GlossTests.swift
+++ b/GlossTests/GlossTests.swift
@@ -77,7 +77,8 @@ class GlossTests: XCTestCase {
             "enumValueArray" : ["A", "B", "C"],
             "date" : "2015-08-16T20:51:46.600Z",
             "dateISO8601" : "2015-08-08T21:57:13Z",
-            "url" : "http://github.com"
+            "url" : "http://github.com",
+            "uuid" : "964F2FE2-0F78-4C2D-A291-03058C0B98AB"
         ]
         
         let model = TestModel(json: testModelsJSON!)
@@ -147,6 +148,7 @@ class GlossTests: XCTestCase {
         XCTAssertTrue((TestModel.dateFormatter.string(from: model1.date!) == "2015-08-16T20:51:46.600Z"), "Model created from JSON should have correct property values")
         XCTAssertTrue((model1.dateISO8601 == Date(timeIntervalSince1970: 1439071033)), "Model created from JSON should have correct property values")
         XCTAssertTrue((model1.url?.absoluteString == "http://github.com"), "Model created from JSON should have correct property values")
+        XCTAssertTrue((model1.uuid?.uuidString == "964F2FE2-0F78-4C2D-A291-03058C0B98AB"), "Model created from JSON should have correct property values")
         
         XCTAssertTrue((model1.nestedModel?.id == 123), "Model created from JSON should have correct property values")
         XCTAssertTrue((model1.nestedModel?.name == "nestedModel1"), "Model created from JSON should have correct property values")
@@ -174,6 +176,7 @@ class GlossTests: XCTestCase {
         XCTAssertTrue((TestModel.dateFormatter.string(from: model1.date!) == "2015-08-16T20:51:46.600Z"), "Model created from JSON should have correct property values")
         XCTAssertTrue((model2.dateISO8601 == Date(timeIntervalSince1970: 1439071033)), "Model created from JSON should have correct property values")
         XCTAssertTrue((model2.url?.absoluteString == "http://github.com"), "Model created from JSON should have correct property values")
+        XCTAssertTrue((model2.uuid?.uuidString == "964F2FE2-0F78-4C2D-A291-03058C0B98AB"), "Model created from JSON should have correct property values")
         
         XCTAssertTrue((model2.nestedModel?.id == 123), "Model created from JSON should have correct property values")
         XCTAssertTrue((model2.nestedModel?.name == "nestedModel1"), "Model created from JSON should have correct property values")
@@ -223,6 +226,8 @@ class GlossTests: XCTestCase {
         
         XCTAssertTrue((json1["url"] as! String == "http://github.com"), "JSON created from model should have correct values")
         
+        XCTAssertTrue((json1["uuid"] as! String == "964F2FE2-0F78-4C2D-A291-03058C0B98AB"), "JSON created from model should have correct values")
+        
         let nestedModel: JSON = json1["nestedModel"] as! JSON
         
         XCTAssertTrue((nestedModel["id"] as! Int == 123), "Encode nested model should return correct value")
@@ -261,6 +266,8 @@ class GlossTests: XCTestCase {
         XCTAssertTrue(resultDate2?.timeIntervalSince1970 == 1439071033, "JSON created from model should have correct values")
         
         XCTAssertTrue((json2["url"] as! String == "http://github.com"), "JSON created from model should have correct values")
+        
+        XCTAssertTrue((json2["uuid"] as! String == "964F2FE2-0F78-4C2D-A291-03058C0B98AB"), "JSON created from model should have correct values")
         
         let nestedModel2: JSON = json2["nestedModel"] as! JSON
         

--- a/GlossTests/KeyPathTests.swift
+++ b/GlossTests/KeyPathTests.swift
@@ -1,0 +1,81 @@
+//
+//  KeyPathTests.swift
+//  Gloss
+//
+//  Created by Maciej Kołek on 10/18/16.
+//  Copyright © 2016 Harlan Kellaway. All rights reserved.
+//
+
+import Gloss
+import XCTest
+
+class KeyPathTests: XCTestCase {
+    
+    var nestedKeyPathJSON: JSON { return
+        [
+            "keyPath" : [
+                "id": 1,
+                "args": [
+                    "name":"foo",
+                    "url":"http://url.com",
+                    "flag" : true
+                ]
+            ]
+        ]
+    }
+    
+    var keyPathJSONWithCustomDelimiter: JSON { return
+        [
+            "nested" : [
+                "id" : 123,
+                "url" : "http://url.com"
+            ]
+        ]
+    }
+    
+    var nestedKeyPathModel: TestNestedKeyPathModel!
+    var keyPathModelWithCustomDelimiter: TestKeyPathModelCustomDelimiter!
+    
+    override func setUp() {
+        super.setUp()
+        
+        nestedKeyPathModel = TestNestedKeyPathModel(json: nestedKeyPathJSON)
+        keyPathModelWithCustomDelimiter = TestKeyPathModelCustomDelimiter(json: keyPathJSONWithCustomDelimiter)
+    }
+    
+    override func tearDown() {
+        nestedKeyPathModel = nil
+        keyPathModelWithCustomDelimiter = nil
+        
+        super.tearDown()
+    }
+    
+    func testNestedKeyPathFromJSON() {
+        XCTAssertTrue(nestedKeyPathModel.keyPathModel?.id == 1, "Should decode with nested key path")
+        XCTAssertTrue(nestedKeyPathModel.keyPathModel?.name == "foo", "Should decode with nested key path")
+        XCTAssertTrue(nestedKeyPathModel.keyPathModel?.url?.absoluteString == "http://url.com", "Should decode with nested key path")
+        XCTAssertTrue(nestedKeyPathModel.flag == true, "Should decode with nested key path")
+    }
+    
+    
+    func testNestedKeyPathToJSON() {
+        XCTAssertTrue((nestedKeyPathModel?.toJSON())! == nestedKeyPathJSON, "Should encode with nested key path")
+    }
+    
+    func testNonDefaultKeyPathDecode() {
+        XCTAssertTrue(keyPathModelWithCustomDelimiter.id == 123, "Should decode model with custom key path delimiter")
+        XCTAssertTrue(keyPathModelWithCustomDelimiter.url?.absoluteString == "http://url.com", "Should decode model with custom key path delimiter")
+    }
+    
+    func testNonDefaultKeyPathEncode() {
+        let result = keyPathModelWithCustomDelimiter.toJSON()
+        
+        let nested = result!["nested"] as! JSON
+        let id = nested["id"] as! Int
+        let url = nested["url"] as! String
+        
+        XCTAssertTrue(id == 123, "Should encode model with custom key path delimiter")
+        XCTAssertTrue(url == "http://url.com", "Should encode model with custom key path delimiter")
+    }
+    
+}

--- a/GlossTests/OperatorTests.swift
+++ b/GlossTests/OperatorTests.swift
@@ -503,4 +503,20 @@ class OperatorTests: XCTestCase {
         XCTAssertTrue(((result!["urlArray"] as! [URL]) == (encoderResult!["urlArray"] as! [URL])), "~~> for url array should return same as Encoder.encodeArray")
     }
     
+    func testEncodeOperatorUUIDReturnsEncoderEncodeUUID() {
+        let uuid: UUID? = UUID(uuidString: "964F2FE2-0F78-4C2D-A291-03058C0B98AB")
+        let result: JSON? = "uuid" ~~> uuid
+        let encoderResult: JSON? = Encoder.encode(uuidForKey: "uuid")(uuid)
+        
+        XCTAssertTrue(((result!["uuid"] as! String) == (encoderResult!["uuid"] as! String)), "~~> for uuid should return same as Encoder.encodeURL")
+    }
+    
+    func testEncodeOperatorUUIDArrayReturnsEncoderEncodeUUIDArray() {
+        let uuids: [UUID]? = [UUID(uuidString: "572099C2-B9AA-42AA-8A25-66E3F3056271")!, UUID(uuidString: "54DB8DCF-F68D-4B55-A3FC-EB8CF4C36B06")!]
+        let result: JSON? = "uuidArray" ~~> uuids
+        let encoderResult: JSON? = Encoder.encode(arrayForKey: "uuidArray")(uuids)
+        
+        XCTAssertTrue(((result!["uuidArray"] as! [UUID]) == (encoderResult!["uuidArray"] as! [UUID])), "~~> for uuid array should return same as Encoder.encodeArray")
+    }
+    
 }

--- a/GlossTests/Test Models/TestKeyPathModel.swift
+++ b/GlossTests/Test Models/TestKeyPathModel.swift
@@ -1,0 +1,33 @@
+//
+//  TestKeyPathModel.swift
+//  GlossExample
+//
+//  Created by Maciej Kołek on 10/18/16.
+//  Copyright © 2016 Harlan Kellaway. All rights reserved.
+//
+
+import Foundation
+import Gloss
+
+struct TestKeyPathModel: Glossy {
+    
+    let id: Int?
+    let name: String?
+    let url: URL?
+    
+    init?(json: JSON) {
+        self.id = "id" <~~ json
+        self.name = "args.name" <~~ json
+        self.url = "args.url" <~~ json
+    }
+    
+    func toJSON() -> JSON? {
+        return jsonify([
+            "id" ~~> self.id,
+            "args.name" ~~> self.name,
+            "args.url" ~~> self.url
+            ])
+    }
+    
+}
+

--- a/GlossTests/Test Models/TestKeyPathModelCustomDelimiter.swift
+++ b/GlossTests/Test Models/TestKeyPathModelCustomDelimiter.swift
@@ -1,0 +1,29 @@
+//
+//  TestKeyPathModelCustomDelimiter.swift
+//  GlossExample
+//
+//  Created by Maciej Kołek on 10/18/16.
+//  Copyright © 2016 Harlan Kellaway. All rights reserved.
+//
+
+import Foundation
+import Gloss
+
+struct TestKeyPathModelCustomDelimiter: Glossy {
+    
+    let id: Int?
+    let url: URL?
+    
+    init?(json: JSON) {
+        self.id = Decoder.decode(key: "nested*id", keyPathDelimiter: "*")(json)
+        self.url = Decoder.decode(urlForKey: "nested*url", keyPathDelimiter: "*")(json)
+    }
+    
+    func toJSON() -> JSON? {
+        return jsonify([
+            "nested*id" ~~> self.id,
+            "nested*url" ~~> self.url
+            ], keyPathDelimiter: "*")
+    }
+    
+}

--- a/GlossTests/Test Models/TestModel.json
+++ b/GlossTests/Test Models/TestModel.json
@@ -56,5 +56,7 @@
 	"uInt64" : 18446744073709551615,
 	"uInt64Array" : [300000000, 9223372036854775808, 18446744073709551615],
 	"url" : "http://github.com",
-    "urlArray" : ["http://github.com", "http://github.com", "http://github.com"]
+    "urlArray" : ["http://github.com", "http://github.com", "http://github.com"],
+    "uuid" : "964F2FE2-0F78-4C2D-A291-03058C0B98AB",
+    "uuidArray" : ["572099C2-B9AA-42AA-8A25-66E3F3056271", "54DB8DCF-F68D-4B55-A3FC-EB8CF4C36B06", "982CED72-743A-45F8-87CF-278386D32EBF"]
 }

--- a/GlossTests/Test Models/TestModel.swift
+++ b/GlossTests/Test Models/TestModel.swift
@@ -57,6 +57,8 @@ struct TestModel: Glossy {
 	let uInt64Array: [UInt64]?
 	let url: URL?
     let urlArray: [URL]?
+    let uuid: UUID?
+    let uuidArray: [UUID]?
     
     enum EnumValue: String {
         case A = "A"
@@ -101,6 +103,8 @@ struct TestModel: Glossy {
 		self.uInt64Array = "uInt64Array" <~~ json
         self.url = "url" <~~ json
         self.urlArray = "urlArray" <~~ json
+        self.uuid = "uuid" <~~ json
+        self.uuidArray = "uuidArray" <~~ json
     }
 
     // MARK: - Serialization
@@ -136,7 +140,9 @@ struct TestModel: Glossy {
 			"uInt64" ~~> self.uInt64,
 			"uInt64Array" ~~> self.uInt64Array,
 			"url" ~~> self.url,
-            "urlArray" ~~> self.urlArray
+            "urlArray" ~~> self.urlArray,
+            "uuid" ~~> self.uuid,
+            "uuidArray" ~~> self.uuidArray
             ])
     }
     

--- a/GlossTests/Test Models/TestNestedKeyPathModel.swift
+++ b/GlossTests/Test Models/TestNestedKeyPathModel.swift
@@ -1,0 +1,29 @@
+//
+//  TestNestedKeyPathModel.swift
+//  Gloss
+//
+//  Created by Maciej Kołek on 10/18/16.
+//  Copyright © 2016 Harlan Kellaway. All rights reserved.
+//
+
+import Foundation
+import Gloss
+
+struct TestNestedKeyPathModel: Glossy {
+    
+    let keyPathModel: TestKeyPathModel?
+    let flag: Bool
+    
+    init?(json: JSON) {
+        self.keyPathModel = "keyPath" <~~ json
+        self.flag = "keyPath.args.flag" <~~ json ?? false
+    }
+    
+    func toJSON() -> JSON? {
+        return jsonify([
+            "keyPath" ~~> self.keyPathModel,
+            "keyPath.args.flag" ~~> self.flag
+            ])
+    }
+    
+}

--- a/Sources/Decoder.swift
+++ b/Sources/Decoder.swift
@@ -481,4 +481,52 @@ public struct Decoder {
         }
     }
     
+    /**
+     Decodes JSON to a UUID.
+     
+     - parameter key: Key used in JSON for decoded value.
+     
+     - returns: Value decoded from JSON.
+     */
+    public static func decode(uuidForKey key: String) -> (JSON) -> UUID? {
+        return {
+            json in
+            
+            if let uuidString = json[key] as? String {
+                return UUID(uuidString: uuidString)
+            }
+             
+            return nil
+        }
+    }
+    
+    /**
+     Decodes JSON to a UUID array.
+     
+     - parameter key: Key used in JSON for decoded value.
+     
+     - returns: Value decoded from JSON.
+     */
+    public static func decode(uuidArrayForKey key: String) -> (JSON) -> [UUID]? {
+        return {
+            json in
+            
+            if let uuidStrings = json[key] as? [String] {
+                var uuids: [UUID] = []
+                
+                for uuidString in uuidStrings {
+                    guard let uuid = UUID(uuidString: uuidString) else {
+                        return nil
+                    }
+                    
+                    uuids.append(uuid)
+                }
+                
+                return uuids
+            }
+            
+            return nil
+        }
+    }
+    
 }

--- a/Sources/Decoder.swift
+++ b/Sources/Decoder.swift
@@ -37,11 +37,11 @@ public struct Decoder {
     
     - returns: Value decoded from JSON.
     */
-    public static func decode<T>(key: String) -> (JSON) -> T? {
+    public static func decode<T>(key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> T? {
         return {
             json in
             
-            if let value = json[key] as? T {
+            if let value = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? T {
                 return value
             }
             
@@ -57,11 +57,11 @@ public struct Decoder {
      
      - returns: Value decoded from JSON.
      */
-    public static func decode(dateForKey key: String, dateFormatter: DateFormatter) -> (JSON) -> Date? {
+    public static func decode(dateForKey key: String, dateFormatter: DateFormatter, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> Date? {
         return {
             json in
             
-            if let dateString = json[key] as? String {
+            if let dateString = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? String {
                 return dateFormatter.date(from: dateString)
             }
             
@@ -77,11 +77,11 @@ public struct Decoder {
      
      - returns: Value decoded from JSON.
      */
-    public static func decode(dateArrayForKey key: String, dateFormatter: DateFormatter) -> (JSON) -> [Date]? {
+    public static func decode(dateArrayForKey key: String, dateFormatter: DateFormatter, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> [Date]? {
         return {
             json in
             
-            if let dateStrings = json[key] as? [String] {
+            if let dateStrings = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? [String] {
                 var dates: [Date] = []
                 
                 for dateString in dateStrings {
@@ -106,8 +106,8 @@ public struct Decoder {
      
      - returns: Value decoded from JSON.
      */
-    public static func decode(dateISO8601ForKey key: String) -> (JSON) -> Date? {
-        return Decoder.decode(dateForKey: key, dateFormatter: GlossDateFormatterISO8601)
+    public static func decode(dateISO8601ForKey key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> Date? {
+        return Decoder.decode(dateForKey: key, dateFormatter: GlossDateFormatterISO8601, keyPathDelimiter: keyPathDelimiter)
     }
     
     /**
@@ -117,8 +117,8 @@ public struct Decoder {
      
      - returns: Value decoded from JSON.
      */
-    public static func decode(dateISO8601ArrayForKey key: String) -> (JSON) -> [Date]? {
-        return Decoder.decode(dateArrayForKey: key, dateFormatter: GlossDateFormatterISO8601)
+    public static func decode(dateISO8601ArrayForKey key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> [Date]? {
+        return Decoder.decode(dateArrayForKey: key, dateFormatter: GlossDateFormatterISO8601, keyPathDelimiter: keyPathDelimiter)
     }
     
     /**
@@ -128,11 +128,11 @@ public struct Decoder {
      
      - returns: Value decoded from JSON.
      */
-    public static func decode<T: Decodable>(decodableForKey key: String) -> (JSON) -> T? {
+    public static func decode<T: Decodable>(decodableForKey key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> T? {
         return {
             json in
             
-            if let subJSON = json[key] as? JSON {
+            if let subJSON = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? JSON {
                 return T(json: subJSON)
             }
             
@@ -148,11 +148,11 @@ public struct Decoder {
      
      - returns: Value decoded from JSON.
      */
-    public static func decode<T: Decodable>(decodableArrayForKey key: String) -> (JSON) -> [T]? {
+    public static func decode<T: Decodable>(decodableArrayForKey key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> [T]? {
         return {
             json in
             
-            if let jsonArray = json[key] as? [JSON] {
+            if let jsonArray = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? [JSON] {
                 var models: [T] = []
                 
                 for subJSON in jsonArray {
@@ -177,11 +177,11 @@ public struct Decoder {
      
      - returns: Value decoded from JSON.
      */
-    public static func decode<T:Decodable>(decodableDictionaryForKey key: String) -> (JSON) -> [String : T]? {
+    public static func decode<T:Decodable>(decodableDictionaryForKey key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> [String : T]? {
         return {
             json in
             
-            guard let dictionary = json[key] as? [String : JSON] else {
+            guard let dictionary = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? [String : JSON] else {
                 return nil
             }
             
@@ -204,11 +204,11 @@ public struct Decoder {
      
      - returns: Value decoded from JSON.
      */
-    public static func decode<T:Decodable>(decodableDictionaryForKey key: String) -> (JSON) -> [String : [T]]? {
+    public static func decode<T:Decodable>(decodableDictionaryForKey key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> [String : [T]]? {
         return {
             json in
             
-            guard let dictionary = json[key] as? [String : [JSON]] else {
+            guard let dictionary = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? [String : [JSON]] else {
                 return nil
             }
             
@@ -231,11 +231,11 @@ public struct Decoder {
      
      - returns: Value decoded from JSON.
      */
-    public static func decode<T: RawRepresentable>(enumForKey key: String) -> (JSON) -> T? {
+    public static func decode<T: RawRepresentable>(enumForKey key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> T? {
         return {
             json in
             
-            if let rawValue = json[key] as? T.RawValue {
+            if let rawValue = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? T.RawValue {
                 return T(rawValue: rawValue)
             }
             
@@ -250,11 +250,11 @@ public struct Decoder {
      
      - returns: Value decoded from JSON.
      */
-    public static func decode<T: RawRepresentable>(enumArrayForKey key: String) -> (JSON) -> [T]? {
+    public static func decode<T: RawRepresentable>(enumArrayForKey key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> [T]? {
         return {
             json in
             
-            if let rawValues = json[key] as? [T.RawValue] {
+            if let rawValues = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? [T.RawValue] {
                 var enumValues: [T] = []
                 
                 for rawValue in rawValues {
@@ -279,11 +279,11 @@ public struct Decoder {
      
      - returns: Value decoded from JSON.
      */
-    public static func decode(int32ForKey key: String) -> (JSON) -> Int32? {
+    public static func decode(int32ForKey key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> Int32? {
         return {
             json in
             
-            if let number = json[key] as? NSNumber {
+            if let number = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? NSNumber {
                 return number.int32Value
             }
             
@@ -298,11 +298,11 @@ public struct Decoder {
      
      - returns: Value decoded from JSON.
      */
-    public static func decode(int32ArrayForKey key: String) -> (JSON) -> [Int32]? {
+    public static func decode(int32ArrayForKey key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> [Int32]? {
         return {
             json in
             
-            if let numbers = json[key] as? [NSNumber] {
+            if let numbers = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? [NSNumber] {
                 let ints: [Int32] = numbers.map { $0.int32Value }
                 
                 return ints
@@ -319,11 +319,11 @@ public struct Decoder {
 
 	- returns: Value decoded from JSON.
 	*/
-	public static func decode(uint32ForKey key: String) -> (JSON) -> UInt32? {
+	public static func decode(uint32ForKey key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> UInt32? {
 		return {
 			json in
 
-			if let number = json[key] as? NSNumber {
+			if let number = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? NSNumber {
 				return number.uint32Value
 			}
 
@@ -338,11 +338,11 @@ public struct Decoder {
 
 	- returns: Value decoded from JSON.
 	*/
-	public static func decode(uint32ArrayForKey key: String) -> (JSON) -> [UInt32]? {
+	public static func decode(uint32ArrayForKey key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> [UInt32]? {
 		return {
 			json in
 
-			if let numbers = json[key] as? [NSNumber] {
+			if let numbers = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? [NSNumber] {
 				let uints: [UInt32] = numbers.map { $0.uint32Value }
 
 				return uints
@@ -359,11 +359,11 @@ public struct Decoder {
 
      - returns: Value decoded from JSON.
      */
-    public static func decode(int64ForKey key: String) -> (JSON) -> Int64? {
+    public static func decode(int64ForKey key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> Int64? {
         return {
             json in
             
-            if let number = json[key] as? NSNumber {
+            if let number = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? NSNumber {
                 return number.int64Value
             }
             
@@ -378,11 +378,11 @@ public struct Decoder {
      
      - returns: Value decoded from JSON.
      */
-    public static func decode(int64ArrayForKey key: String) -> (JSON) -> [Int64]? {
+    public static func decode(int64ArrayForKey key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> [Int64]? {
         return {
             json in
             
-            if let numbers = json[key] as? [NSNumber] {
+            if let numbers = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? [NSNumber] {
                 let ints: [Int64] = numbers.map { $0.int64Value }
                 
                 return ints
@@ -399,11 +399,11 @@ public struct Decoder {
 
 	- returns: Value decoded from JSON.
 	*/
-	public static func decode(uint64ForKey key: String) -> (JSON) -> UInt64? {
+	public static func decode(uint64ForKey key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> UInt64? {
 		return {
 			json in
 
-			if let number = json[key] as? NSNumber {
+			if let number = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? NSNumber {
 				return number.uint64Value
 			}
 
@@ -418,11 +418,11 @@ public struct Decoder {
 
 	- returns: Value decoded from JSON.
 	*/
-	public static func decode(uint64ArrayForKey key: String) -> (JSON) -> [UInt64]? {
+	public static func decode(uint64ArrayForKey key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> [UInt64]? {
 		return {
 			json in
 
-			if let numbers = json[key] as? [NSNumber] {
+			if let numbers = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? [NSNumber] {
 				let uints: [UInt64] = numbers.map { $0.uint64Value }
 
 				return uints
@@ -439,11 +439,11 @@ public struct Decoder {
 
      - returns: Value decoded from JSON.
      */
-    public static func decode(urlForKey key: String) -> (JSON) -> URL? {
+    public static func decode(urlForKey key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> URL? {
         return {
             json in
             
-            if let urlString = json[key] as? String,
+            if let urlString = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? String,
                 let encodedString = urlString.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed) {
                 return URL(string: encodedString)
             }
@@ -459,11 +459,11 @@ public struct Decoder {
      
      - returns: Value decoded from JSON.
      */
-    public static func decode(urlArrayForKey key: String) -> (JSON) -> [URL]? {
+    public static func decode(urlArrayForKey key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> [URL]? {
         return {
             json in
             
-            if let urlStrings = json[key] as? [String] {
+            if let urlStrings = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? [String] {
                 var urls: [URL] = []
                 
                 for urlString in urlStrings {

--- a/Sources/Encoder.swift
+++ b/Sources/Encoder.swift
@@ -464,7 +464,7 @@ public struct Encoder {
             return nil
         }
     }
-    
+
     /**
      Encodes a UUID to JSON.
      

--- a/Sources/Encoder.swift
+++ b/Sources/Encoder.swift
@@ -465,4 +465,22 @@ public struct Encoder {
         }
     }
     
+    /**
+     Encodes a UUID to JSON.
+     
+     - parameter key: Key used in JSON for decoded value.
+     
+     - returns: JSON encoded from value.
+     */
+    public static func encode(uuidForKey key: String) -> (UUID?) -> JSON? {
+        return {
+            uuid in
+            
+            if let uuidString = uuid?.uuidString {
+                return [key : uuidString]
+            }
+            
+            return nil
+        }
+    }
 }

--- a/Sources/ExtensionDictionary.swift
+++ b/Sources/ExtensionDictionary.swift
@@ -24,8 +24,31 @@
 //
 
 import Foundation
-
-internal extension Dictionary {
+public extension Dictionary {
+    // MARK: - Public Functions
+    /**
+     Retrieves value from dictionary given a key path delimited with
+     provided delimiter to indicate a nested value.
+     
+     For example, a dictionary with [ "outer" : [ "inner" : "value" ] ]
+     could retrive 'value' via  path "outer.inner", given a
+     delimiter of ''.
+     
+     - parameter keyPath:   Key path delimited by delimiter.
+     - parameter delimiter: Delimiter.
+     
+     - returns: Value retrieved from dic
+     */
+    public func valueForKeyPath(keyPath: String, withDelimiter delimiter: String = GlossKeyPathDelimiter) -> Any? {
+        let keys = keyPath.components(separatedBy: delimiter)
+        
+        guard keys.first as? Key != nil else {
+            print("[Gloss] Unable to use keyPath '\(keyPath)' as key on type: \(Key.self)")
+            return nil
+        }
+        
+        return self.findValue(keys: keys)
+    }
     
     // MARK: - Internal functions
     
@@ -36,7 +59,7 @@ internal extension Dictionary {
     
     - parameter elements: Elements to add to the new dictionary.
     */
-    init(elements: [Element]) {
+    internal init(elements: [Element]) {
         self.init()
         
         for (key, value) in elements {
@@ -51,25 +74,28 @@ internal extension Dictionary {
      
      - returns: New dictionary of transformed values.
      */
-    func flatMap<KeyPrime : Hashable, ValuePrime>(_ transform: (Key, Value) throws -> (KeyPrime, ValuePrime)?) rethrows -> [KeyPrime : ValuePrime] {
+    internal func flatMap<KeyPrime : Hashable, ValuePrime>(_ transform: (Key, Value) throws -> (KeyPrime, ValuePrime)?) rethrows -> [KeyPrime : ValuePrime] {
         return Dictionary<KeyPrime,ValuePrime>(elements: try flatMap({ (key, value) in
             return try transform(key, value)
         }))
     }
     
     /**
-     Adds entries from provided dictionary to current dictionary.
+     Retrieves value from dictionary given a key path delimited with
+     provided delimiter by going down the dictionary stack tree
      
-     Note: If current dictionary and provided dictionary have the same
-     key, the value from the provided dictionary overwrites current value.
-     
-     - parameter other:     Dictionary to add entries from
-     - parameter delimiter: Key path delimiter
+     - parameter keys: Array of keys splited by delimiter
+     - parameter depthLevel: Indicates current depth level in the dictionary tree
+     - returns: object retrieved from dic
      */
-    mutating func add(other: Dictionary) -> () {
-        for (key, value) in other {
-            self.updateValue(value, forKey:key)
+    private func findValue(keys: [String], depthLevel: Int = 0) -> Any? {
+        if let currentKey = keys[depthLevel] as? Key {
+            if depthLevel == keys.count-1 {
+                return self[currentKey]
+            } else if let newDict = self[currentKey] as? Dictionary {
+                return newDict.findValue(keys: keys, depthLevel: depthLevel+1)
+            }
         }
+        return nil
     }
-    
 }

--- a/Sources/Operators.swift
+++ b/Sources/Operators.swift
@@ -242,6 +242,30 @@ public func <~~ (key: String, json: JSON) -> [URL]? {
     return Decoder.decode(urlArrayForKey: key)(json)
 }
 
+/**
+ Convenience operator for decoding JSON to UUID.
+ 
+ - parameter key:  JSON key for value to decode.
+ - parameter json: JSON.
+ 
+ - returns: Decoded value when successful, nil otherwise.
+ */
+public func <~~ (key: String, json: JSON) -> UUID? {
+    return Decoder.decode(uuidForKey: key)(json)
+}
+
+/**
+ Convenience operator for decoding JSON to array of UUIDs.
+ 
+ - parameter key:  JSON key for value to decode.
+ - parameter json: JSON.
+ 
+ - returns: Decoded value when successful, nil otherwise.
+ */
+public func <~~ (key: String, json: JSON) -> [UUID]? {
+    return Decoder.decode(uuidArrayForKey: key)(json)
+}
+
 // MARK: - Operator ~~> (Encode)
 
 precedencegroup EncodingPrecedence {
@@ -460,4 +484,16 @@ public func ~~> (key: String, property: [UInt64]?) -> JSON? {
  */
 public func ~~> (key: String, property: URL?) -> JSON? {
     return Encoder.encode(urlForKey: key)(property)
+}
+
+/**
+ Convenience operator for encoding a UUID to JSON.
+ 
+ - parameter key:      JSON key for value to encode.
+ - parameter property: Object to encode to JSON.
+ 
+ - returns: JSON when successful, nil otherwise.
+ */
+public func ~~> (key: String, property: UUID?) -> JSON? {
+    return Encoder.encode(uuidForKey: key)(property)
 }


### PR DESCRIPTION
Hey @hkellaway :)
After your recent changes regarding deprecating nested keypaths in Gloss (https://github.com/hkellaway/Gloss/issues/135), we faced a huge problem - we have A LOT of models using that feature, and we could:
- ditch the Gloss completely (while we admire it a lot ) ❌ 
- switch to ObjectMapper (or any other library supporting the feature) ❌ 
- or just simply fix the issue ✌️ 

I am happy to say that after few days of sorting that all out, my pull request is reintroducing the nested keypaths. It supports **Swift 3.0** directly and does not need to disable swift optimizations. I've also reintroduced and modified tests that you've previously had for the feature.

For those who are interested what was wrong - for `Encoder` it seems that when you put a lot of hard-logic code into Dictionary extension, the compiler is acting weird. I am also passing the sub-dictionaries by reference, so it does not create a new copy. For `Decoder`, I've rewritten the function to find the element by the keypath so it uses a recursive function to traverse the tree.

For those who are interested, there is also a `fixes_for_nested` branch in my fork for **Swift 2.3**: https://github.com/ferusinfo/Gloss/tree/fixes_for_nested

I hope we can discuss the changes and merge it - so we can keep using the Gloss as our favorite JSON parsing library.