### PR TITLE
Support nested keys for `UUID`s.

### DIFF
--- a/Sources/Decoder.swift
+++ b/Sources/Decoder.swift
@@ -488,11 +488,11 @@ public struct Decoder {
      
      - returns: Value decoded from JSON.
      */
-    public static func decode(uuidForKey key: String) -> (JSON) -> UUID? {
+    public static func decode(uuidForKey key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> UUID? {
         return {
             json in
             
-            if let uuidString = json[key] as? String {
+            if let uuidString = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? String {
                 return UUID(uuidString: uuidString)
             }
              
@@ -507,11 +507,11 @@ public struct Decoder {
      
      - returns: Value decoded from JSON.
      */
-    public static func decode(uuidArrayForKey key: String) -> (JSON) -> [UUID]? {
+    public static func decode(uuidArrayForKey key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> [UUID]? {
         return {
             json in
             
-            if let uuidStrings = json[key] as? [String] {
+            if let uuidStrings = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? [String] {
                 var uuids: [UUID] = []
                 
                 for uuidString in uuidStrings {

--- a/Tests/GlossTests/DecoderTests.swift
+++ b/Tests/GlossTests/DecoderTests.swift
@@ -248,6 +248,19 @@ class DecoderTests: XCTestCase {
         XCTAssertTrue((result?.id == 123), "Decode nested model should return correct value")
         XCTAssertTrue((result?.name == "nestedModel1"), "Decode nested model should return correct value")
     }
+
+    func testNestedDecode() {
+        let id: Int? = Decoder.decode(key: "nestedModel.id")(testJSON!)
+        let name: String? = Decoder.decode(key: "nestedModel.name")(testJSON!)
+
+        let uuid: UUID? = Decoder.decode(uuidForKey: "nestedModel.uuid")(testJSON!)
+        let url: URL? = Decoder.decode(urlForKey: "nestedModel.url")(testJSON!)
+
+        XCTAssertTrue((id == 123), "Decode using nested key should return correct value")
+        XCTAssertTrue((name == "nestedModel1"), "Decode using nested key should return correct value")
+        XCTAssertTrue((uuid?.uuidString == "BA34F5F0-E5AA-4ECE-B25C-90195D7AF0D0"), "Decode using nested key should return correct value")
+        XCTAssertTrue((url?.absoluteString == "http://github.com"), "Decode using nested key should return correct value")
+    }
     
     func testDecodeEnumValue() {
         let result: TestModel.EnumValue? = Decoder.decode(enumForKey: "enumValue")(testJSON!)

--- a/Tests/GlossTests/Test Models/TestModel.json
+++ b/Tests/GlossTests/Test Models/TestModel.json
@@ -29,7 +29,9 @@
     "stringArray" : ["def", "ghi", "jkl"],
     "nestedModel" : {
         "id" : 123,
-        "name" : "nestedModel1"
+        "name" : "nestedModel1",
+        "uuid": "BA34F5F0-E5AA-4ECE-B25C-90195D7AF0D0",
+        "url": "http://github.com"
     },
     "nestedModelArray" : [
                           {

--- a/Tests/GlossTests/Test Models/TestModel.swift
+++ b/Tests/GlossTests/Test Models/TestModel.swift
@@ -191,7 +191,9 @@ extension TestModel {
             "stringArray" : ["def", "ghi", "jkl"],
             "nestedModel" : [
                 "id" : 123,
-                "name" : "nestedModel1"
+                "name" : "nestedModel1",
+                "uuid" : "BA34F5F0-E5AA-4ECE-B25C-90195D7AF0D0",
+                "url" : "http://github.com"
             ],
             "nestedModelArray" : [
             [


### PR DESCRIPTION
Was just using `1.1.0` on with UUIDs and noticed that they weren't decoding properly with nested keys.

So, fixed it and added a `testNestedDecode()` test to test nested decoding since I didn't see one already.

Note that I added some keys to `nestedModel` in `TestModel.(json|swift)`.  All the tests pass but wanted to make sure you were aware, just in case I missed somewhere else that needs updating.