### PR TITLE
mention OctoAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,7 @@ Check out Gloss in these cool places!
 * [CRUD](https://github.com/MetalheadSanya/CRUD)
 * [Moya-Gloss](https://github.com/spxrogers/Moya-Gloss)
 * [Restofire-Gloss](https://github.com/Restofire/Restofire-Gloss)
+* [OctoAPI](http://github.com/ferusinfo/OctoAPI)
 
 #### SDKs/Products
 


### PR DESCRIPTION
I've just released my library - OctoAPI - an JSON API abstraction layer to use in iOS projects written in Swift and I am using a built-in Gloss data parser in it.
Can you add a mention about it to your list of Libraries using Gloss? :)