### PR TITLE
decode double

### DIFF
--- a/Sources/Decoder.swift
+++ b/Sources/Decoder.swift
@@ -529,4 +529,21 @@ public struct Decoder {
         }
     }
     
+    /**
+     Decodes JSON to a Double.
+     
+     - parameter key: Key used in JSON for decoded value.
+     
+     - returns: Value decoded from JSON.
+     */
+    public static func decode(doubleForKey key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> Double? {
+            return {
+                json in
+                
+                if let doubleString = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? String, let doubleNum = Double(doubleString) {
+                    return doubleNum
+                }
+                return nil
+            }
+    }
 }


### PR DESCRIPTION
While we were developing some features for our app, we've came across the problem that when Alamofire is returning the JSON object, the Double values in original JSON are represented as `NSTaggedPointerString` and therefore, we cannot automatically assign the Double via `<~~` operators.
I've created another function for Decoder.
Hope it can be merged.