### PR TITLE
[HotFix] Missing import Foundation

### DIFF
--- a/Tests/GlossTests/Test Models/TestNestedModel.swift
+++ b/Tests/GlossTests/Test Models/TestNestedModel.swift
@@ -23,6 +23,7 @@
 // THE SOFTWARE.
 //
 
+import Foundation
 import Gloss
 
 struct TestNestedModel: Glossy {


### PR DESCRIPTION
Adding missing `import Foundation`. I was not able to build Gloss without this on Ubuntu 16.10.