### PR TITLE
Decodable protocol extension with initializers accepting raw Data

### DIFF
--- a/Gloss.xcodeproj/project.pbxproj
+++ b/Gloss.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		2F3A83461C66D11200ECC4B8 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3A832E1C66CF3C00ECC4B8 /* Operators.swift */; };
 		2F3A83471C66D11600ECC4B8 /* Gloss.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F3A832B1C66CF3C00ECC4B8 /* Gloss.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2FA4CE9F1C947E3000EB8AB8 /* Gloss.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC39BF611B8A7AD200088CE0 /* Gloss.framework */; };
+		8E96F1471E1C359B00B1B702 /* Decodable+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E96F1461E1C359B00B1B702 /* Decodable+Extension.swift */; };
 		9F055DC81DCBC24000EB78C1 /* Comparators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F055DBF1DCBC24000EB78C1 /* Comparators.swift */; };
 		9F055DC91DCBC24000EB78C1 /* DecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F055DC01DCBC24000EB78C1 /* DecoderTests.swift */; };
 		9F055DCA1DCBC24000EB78C1 /* EncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F055DC11DCBC24000EB78C1 /* EncoderTests.swift */; };
@@ -74,6 +75,7 @@
 		2F3A832D1C66CF3C00ECC4B8 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Sources/Info.plist; sourceTree = SOURCE_ROOT; };
 		2F3A832E1C66CF3C00ECC4B8 /* Operators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Operators.swift; path = Sources/Operators.swift; sourceTree = SOURCE_ROOT; };
 		2FA4CE9A1C947E3000EB8AB8 /* GlossTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GlossTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		8E96F1461E1C359B00B1B702 /* Decodable+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Decodable+Extension.swift"; path = "Sources/Decodable+Extension.swift"; sourceTree = SOURCE_ROOT; };
 		9F055DBF1DCBC24000EB78C1 /* Comparators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Comparators.swift; path = Tests/GlossTests/Comparators.swift; sourceTree = SOURCE_ROOT; };
 		9F055DC01DCBC24000EB78C1 /* DecoderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DecoderTests.swift; path = Tests/GlossTests/DecoderTests.swift; sourceTree = SOURCE_ROOT; };
 		9F055DC11DCBC24000EB78C1 /* EncoderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EncoderTests.swift; path = Tests/GlossTests/EncoderTests.swift; sourceTree = SOURCE_ROOT; };
@@ -197,6 +199,7 @@
 		DC39BF631B8A7AD200088CE0 /* Gloss */ = {
 			isa = PBXGroup;
 			children = (
+				8E96F1461E1C359B00B1B702 /* Decodable+Extension.swift */,
 				2F3A83281C66CF3C00ECC4B8 /* Decoder.swift */,
 				2F3A832A1C66CF3C00ECC4B8 /* Encoder.swift */,
 				DCD40A5E1C7A7B11007EE251 /* ExtensionArray.swift */,
@@ -472,6 +475,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2F3A832F1C66CF3C00ECC4B8 /* Decoder.swift in Sources */,
+				8E96F1471E1C359B00B1B702 /* Decodable+Extension.swift in Sources */,
 				2F3A83351C66CF3C00ECC4B8 /* Operators.swift in Sources */,
 				2F3A83331C66CF3C00ECC4B8 /* Gloss.swift in Sources */,
 				DCD40A601C7A7B11007EE251 /* ExtensionArray.swift in Sources */,

--- a/Sources/Decodable+Extension.swift
+++ b/Sources/Decodable+Extension.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-extension Decodable {
+public extension Decodable {
     
     /**
      Initializes model object of type which implements protocol.
@@ -34,12 +34,10 @@ extension Decodable {
      
      - returns: Object or nil.
      */
-    init?(data: Data?) {
-        if let data = data {
-            if let json = (try? JSONSerialization.jsonObject(with: data, options: .mutableContainers)) as? [String: Any] {
-                self.init(json: json)
-                return
-            }
+    init?(data: Data) {
+        if let json = (try? JSONSerialization.jsonObject(with: data, options: .mutableContainers)) as? JSON {
+            self.init(json: json)
+            return
         }
         
         return nil
@@ -54,12 +52,10 @@ extension Decodable {
      
      - returns: Array containing objects of type which implements protocol.
      */
-    static func array(from data: Data?) -> [Self] {
-        if let data = data {
-            if let json = (try? JSONSerialization.jsonObject(with: data, options: .mutableContainers)) as? [[String: Any]] {
-                if let array = [Self].from(jsonArray: json) {
-                    return array
-                }
+    static func array(from data: Data) -> [Self] {
+        if let json = (try? JSONSerialization.jsonObject(with: data, options: .mutableContainers)) as? [JSON] {
+            if let array = [Self].from(jsonArray: json) {
+                return array
             }
         }
         

--- a/Sources/Decodable+Extension.swift
+++ b/Sources/Decodable+Extension.swift
@@ -1,0 +1,69 @@
+//
+//  Decodable+Extension.swift
+//  Gloss
+//
+// Copyright © 2017 https://github.com/kampro
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+extension Decodable {
+    
+    /**
+     Initializes model object of type which implements protocol.
+     If data are incorrect returns nil.
+     
+     - parameter data: Raw JSON data, i.e. received from server.
+     
+     - returns: Object or nil.
+     */
+    init?(data: Data?) {
+        if let data = data {
+            if let json = (try? JSONSerialization.jsonObject(with: data, options: .mutableContainers)) as? [String: Any] {
+                self.init(json: json)
+                return
+            }
+        }
+        
+        return nil
+    }
+    
+    
+    /**
+     Initializes array of model objects of type which implements protocol.
+     If data are incorrect returned array is empty.
+     
+     - parameter data: Raw JSON array data, i.e. received from server.
+     
+     - returns: Array containing objects of type which implements protocol.
+     */
+    static func array(from data: Data?) -> [Self] {
+        if let data = data {
+            if let json = (try? JSONSerialization.jsonObject(with: data, options: .mutableContainers)) as? [[String: Any]] {
+                if let array = [Self].from(jsonArray: json) {
+                    return array
+                }
+            }
+        }
+        
+        return [Self]()
+    }
+    
+}

--- a/Tests/GlossTests/GlossTests.swift
+++ b/Tests/GlossTests/GlossTests.swift
@@ -318,4 +318,18 @@ class GlossTests: XCTestCase {
         XCTAssertTrue(result!.isEmpty, "Jsonify should return empty JSON when given an empty array")
     }
     
+    func testModelFromJSONRawData() {
+        let data = try! JSONSerialization.data(withJSONObject: testModelsJSON!, options: [])
+        let model = TestModel(data: data)
+        
+        XCTAssertNotNil(model, "Model from Data should not be nil.")
+    }
+    
+    func testModelArrayFromJSONArrayRawData() {
+        let data = try! JSONSerialization.data(withJSONObject: testJSONArray!, options: [])
+        let modelArray = TestModel.array(from: data)
+        
+        XCTAssertGreaterThan(modelArray.count, 0, "Number of elements in array from Data should be grater than 0.")
+    }
+    
 }


### PR DESCRIPTION
You can just initialize model directly from Data type.
Example:
`struct Foo: Decodable {
...
}`
`if let foo = Foo(data: jsonData) { ... }`
or for array:
`struct Bar: Decodable {
...
}`
`let arrayOfBar = Bar.array(from: jsonArrayData)`