### PR TITLE
[HotFix] Update usage of ISO8601DateFormatter on Linux

### DIFF
--- a/Sources/Gloss.swift
+++ b/Sources/Gloss.swift
@@ -71,8 +71,10 @@ public protocol GlossDateFormatter {
     func string(from date: Date) -> String
 }
 
+#if os(iOS)
 @available(iOSApplicationExtension 10.0, *)
 extension ISO8601DateFormatter: GlossDateFormatter {}
+#endif
 
 extension DateFormatter: GlossDateFormatter {} 
 /**
@@ -82,9 +84,11 @@ Date formatter used for ISO8601 dates.
  */
 public private(set) var GlossDateFormatterISO8601: GlossDateFormatter = {
 
+	#if os(iOS)
     if #available(iOSApplicationExtension 10.0, *) {
         return ISO8601DateFormatter()
     }
+	#endif
 
     let dateFormatterISO8601 = DateFormatter()
     

--- a/Tests/GlossTests/GlossTests.swift
+++ b/Tests/GlossTests/GlossTests.swift
@@ -123,10 +123,12 @@ class GlossTests: XCTestCase {
         XCTAssertTrue(dateFormatterISO8601.dateFormat == "yyyy-MM-dd'T'HH:mm:ssZZZZZ", "Date formatter ISO8601 should have correct date format.")
     }
 
+	#if os(iOS)
     @available(iOS 10.0, *)
     func testDateFormatterReturnsFoundationVersion() {
         XCTAssert(GlossDateFormatterISO8601 is ISO8601DateFormatter)
     }
+	#endif
 
     func testDateFormatterISO8601ForcesGregorianCalendar() {
         if #available(iOS 10.0, *) {


### PR DESCRIPTION
This updates work of ec67dd134a7c6ecfd47db89be0deaf644473aa3c (#253) to work on Linux...
It seems that ISO8601DateFormatter is not yet available on Linux. Not sure why... :confused: