### PR TITLE
Reverted usage of new ISO8601DateFormatter

### DIFF
--- a/Sources/Decoder.swift
+++ b/Sources/Decoder.swift
@@ -57,7 +57,7 @@ public struct Decoder {
      
      - returns: Value decoded from JSON.
      */
-    public static func decode(dateForKey key: String, dateFormatter: GlossDateFormatter, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> Date? {
+    public static func decode(dateForKey key: String, dateFormatter: DateFormatter, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> Date? {
         return {
             json in
             
@@ -77,7 +77,7 @@ public struct Decoder {
      
      - returns: Value decoded from JSON.
      */
-    public static func decode(dateArrayForKey key: String, dateFormatter: GlossDateFormatter, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> [Date]? {
+    public static func decode(dateArrayForKey key: String, dateFormatter: DateFormatter, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> [Date]? {
         return {
             json in
             

--- a/Sources/Encoder.swift
+++ b/Sources/Encoder.swift
@@ -76,7 +76,7 @@ public struct Encoder {
      
      - returns: JSON encoded from value.
      */
-    public static func encode(dateForKey key: String, dateFormatter: GlossDateFormatter) -> (Date?) -> JSON? {
+    public static func encode(dateForKey key: String, dateFormatter: DateFormatter) -> (Date?) -> JSON? {
         return {
             date in
             
@@ -96,7 +96,7 @@ public struct Encoder {
      
      - returns: JSON encoded from value.
      */
-    public static func encode(dateArrayForKey key: String, dateFormatter: GlossDateFormatter) -> ([Date]?) -> JSON? {
+    public static func encode(dateArrayForKey key: String, dateFormatter: DateFormatter) -> ([Date]?) -> JSON? {
         return {
             dates in
             

--- a/Sources/Gloss.swift
+++ b/Sources/Gloss.swift
@@ -68,25 +68,14 @@ public protocol Encodable {
 
 // MARK: - Global
 
-public protocol GlossDateFormatter {
-    func date(from string: String) -> Date?
-    func string(from date: Date) -> String
-}
+// MARK: DateFormatter
 
-@available(iOSApplicationExtension 10.0, *)
-extension ISO8601DateFormatter: GlossDateFormatter {}
-
-extension DateFormatter: GlossDateFormatter {} 
 /**
 Date formatter used for ISO8601 dates.
  
  - returns: Date formatter.
  */
-public private(set) var GlossDateFormatterISO8601: GlossDateFormatter = {
-
-    if #available(iOSApplicationExtension 10.0, *) {
-        return ISO8601DateFormatter()
-    }
+public private(set) var GlossDateFormatterISO8601: DateFormatter = {
 
     let dateFormatterISO8601 = DateFormatter()
     

--- a/Tests/GlossTests/GlossTests.swift
+++ b/Tests/GlossTests/GlossTests.swift
@@ -103,29 +103,15 @@ class GlossTests: XCTestCase {
     }
     
     func testDateFormatterISO8601HasCorrectLocale() {
-        if #available(iOS 10.0, *) {
-            XCTAssert(true)
-            return
-        }
-
         let dateFormatterISO8601 = GlossDateFormatterISO8601 as! DateFormatter
         
         XCTAssertTrue(dateFormatterISO8601.locale.identifier == "en_US_POSIX", "Date formatter ISO8601 should have correct locale.")
     }
     
     func testDateFormatterISO8601HasCorrectDateFormat() {
-        if #available(iOS 10.0, *) {
-            XCTAssert(true)
-            return
-        }
         let dateFormatterISO8601 = GlossDateFormatterISO8601 as! DateFormatter
         
         XCTAssertTrue(dateFormatterISO8601.dateFormat == "yyyy-MM-dd'T'HH:mm:ssZZZZZ", "Date formatter ISO8601 should have correct date format.")
-    }
-
-    @available(iOS 10.0, *)
-    func testDateFormatterReturnsFoundationVersion() {
-        XCTAssert(GlossDateFormatterISO8601 is ISO8601DateFormatter)
     }
 
     func testDateFormatterISO8601ForcesGregorianCalendar() {


### PR DESCRIPTION
Reverting usage of `ISO8601DateFormatter` (introduced here https://github.com/hkellaway/Gloss/pull/253), as it broke usage on Mac OSX, tvOS, and watch OS