### PR TITLE
Add global default logger

### DIFF
--- a/Sources/Decoder.swift
+++ b/Sources/Decoder.swift
@@ -30,6 +30,9 @@ Decodes JSON to objects.
 */
 public struct Decoder {
     
+    /// Default logger
+    public static var logger: Logger = GlossLogger()
+    
     /**
      Decodes JSON to a generic value.
     
@@ -37,7 +40,7 @@ public struct Decoder {
     
     - returns: Value decoded from JSON.
     */
-    public static func decode<T>(key: String, keyPathDelimiter: String = GlossKeyPathDelimiter, logger: Logger = GlossLogger()) -> (JSON) -> T? {
+    public static func decode<T>(key: String, keyPathDelimiter: String = GlossKeyPathDelimiter, logger: Logger = logger) -> (JSON) -> T? {
         return {
             json in
             

--- a/Tests/GlossTests/DecoderTests.swift
+++ b/Tests/GlossTests/DecoderTests.swift
@@ -103,6 +103,16 @@ class DecoderTests: XCTestCase {
         XCTAssertTrue(fakeLogger.wasMessageLogged, "Message should be logged when an unknown type is attempted to be decoded.")
     }
     
+    func testDecodingModelWithUnknownTypeLogsErrorMessageInInjectedDefaultLogger() {
+        let fakeLogger = FakeLogger()
+        Decoder.logger = fakeLogger
+        
+        let value: UnknownType? = Decoder.decode(key: "value")(testUnknownTypeJSON!)
+        
+        XCTAssertNil(value)
+        XCTAssertTrue(fakeLogger.wasMessageLogged, "Message should be logged when an unknown type is attempted to be decoded.")
+    }
+    
     func testInitializingFailableObjectsWithBadDataCanFail() {
         let result = TestFailableModel(json: testFailableModelJSONInvalid!)
         


### PR DESCRIPTION
This change allows users to inject a custom default logger while still using the custom operators instead of the plain decode function.