### PR TITLE
Adds a Double decoder.

### DIFF
--- a/Sources/Decoder.swift
+++ b/Sources/Decoder.swift
@@ -541,6 +541,46 @@ public struct Decoder {
     }
     
     /**
+     Decodes JSON to an Double.
+     
+     - parameter key: Key used in JSON for decoded value.
+     
+     - returns: Value decoded from JSON.
+     */
+    public static func decode(doubleForKey key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> Double? {
+        return {
+            json in
+            
+            if let number = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? NSNumber {
+                return number.doubleValue
+            }
+            
+            return nil
+        }
+    }
+    
+    /**
+     Decodes JSON to an Double array.
+     
+     - parameter key: Key used in JSON for decoded value.
+     
+     - returns: Value decoded from JSON.
+     */
+    public static func decode(doubleArrayForKey key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> [Double]? {
+        return {
+            json in
+            
+            if let numbers = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? [NSNumber] {
+                let doubles: [Double] = numbers.map { $0.doubleValue }
+                
+                return doubles
+            }
+            
+            return nil
+        }
+    }
+    
+    /**
      Decodes JSON to a Decimal.
      
      - parameter key: Key used in JSON for decoded value.

--- a/Sources/Encoder.swift
+++ b/Sources/Encoder.swift
@@ -483,9 +483,49 @@ public struct Encoder {
             return nil
         }
     }
+   
+    /**
+     Encodes a Double array to JSON.
+     
+     - parameter key: Key used in JSON for decoded value.
+     
+     - returns: JSON encoded from value.
+     */
+    public static func encode(doubleForKey key: String) -> (Double?) -> JSON? {
+        return {
+            double in
+            
+            if let double = double {
+                return [key : NSNumber(value: double)]
+            }
+            
+            return nil
+        }
+    }
     
     /**
-     Encodes a Decimal to JSON.
+     Encodes a Double array to JSON.
+     
+     - parameter key: Key used in JSON for decoded value.
+     
+     - returns: JSON encoded from value.
+     */
+    public static func encode(doubleArrayForKey key: String) -> ([Double]?) -> JSON? {
+        return {
+            doubleArray in
+            
+            if let doubleArray = doubleArray {
+                let numbers: [NSNumber] = doubleArray.map { NSNumber(value: $0) }
+                
+                return [key : numbers]
+            }
+            
+            return nil
+        }
+    }
+
+    /**
+     Encodes a Double to JSON.
      
      - parameter key: Key used in JSON for decoded value.
      

--- a/Sources/Operators.swift
+++ b/Sources/Operators.swift
@@ -267,6 +267,30 @@ public func <~~ (key: String, json: JSON) -> [UUID]? {
 }
 
 /**
+ Convenience operator for decoding JSON to Double.
+ 
+ - parameter key:  JSON key for value to decode.
+ - parameter json: JSON.
+ 
+ - returns: Decoded value when successful, nil otherwise.
+ */
+public func <~~ (key: String, json: JSON) -> Double? {
+    return Decoder.decode(doubleForKey: key)(json)
+}
+
+/**
+ Convenience operator for decoding JSON to Double array.
+ 
+ - parameter key:  JSON key for value to decode.
+ - parameter json: JSON.
+ 
+ - returns: Decoded value when successful, nil otherwise.
+ */
+public func <~~ (key: String, json: JSON) -> [Double]? {
+    return Decoder.decode(doubleArrayForKey: key)(json)
+}
+
+/**
  Convenience operator for decoding JSON to Decimal.
  
  - parameter key:  JSON key for value to decode.

--- a/Sources/Operators.swift
+++ b/Sources/Operators.swift
@@ -547,6 +547,30 @@ public func ~~> (key: String, property: UUID?) -> JSON? {
 }
 
 /**
+ Convenience operator for encoding a Double to JSON.
+ 
+ - parameter key:      JSON key for value to encode.
+ - parameter property: Object to encode to JSON.
+ 
+ - returns: JSON when successful, nil otherwise.
+ */
+public func ~~> (key: String, property: Double?) -> JSON? {
+    return Encoder.encode(doubleForKey: key)(property)
+}
+
+/**
+ Convenience operator for encoding a Double array to JSON.
+ 
+ - parameter key:      JSON key for value to encode.
+ - parameter property: Object to encode to JSON.
+ 
+ - returns: JSON when successful, nil otherwise.
+ */
+public func ~~> (key: String, property: [Double]?) -> JSON? {
+    return Encoder.encode(doubleArrayForKey: key)(property)
+}
+
+/**
  Convenience operator for encoding a Decimal to JSON.
  
  - parameter key:      JSON key for value to encode.

--- a/Tests/GlossTests/DecoderTests.swift
+++ b/Tests/GlossTests/DecoderTests.swift
@@ -199,19 +199,19 @@ class DecoderTests: XCTestCase {
     }
     
     func testDecodeDouble() {
-        let result: Double? = Decoder.decode(key: "double")(testJSON!)
+        let result: Double? = Decoder.decode(doubleForKey: "double")(testJSON!)
         
         XCTAssertTrue((result == 6.0), "Decode Double should return correct value")
     }
     
     func testDecodeDoubleArray() {
-        let result: [Double]? = Decoder.decode(key: "doubleArray")(testJSON!)
+        let result: [Double]? = Decoder.decode(doubleArrayForKey: "doubleArray")(testJSON!)
         let element1: Double = result![0]
         let element2: Double = result![1]
         let element3: Double = result![2]
         
         XCTAssertTrue((element1 == 4.0), "Decode Double array should return correct value")
-        XCTAssertTrue((element2 == 5.0), "Decode Double array should return correct value")
+        XCTAssertTrue((element2 == 5), "Decode Double array should return correct value")
         XCTAssertTrue((element3 == 6.0), "Decode Double array should return correct value")
     }
     

--- a/Tests/GlossTests/EncoderTests.swift
+++ b/Tests/GlossTests/EncoderTests.swift
@@ -118,14 +118,14 @@ class EncoderTests: XCTestCase {
     
     func testEncodeDouble() {
         let double: Double? = 4.0
-        let result: JSON? = Encoder.encode(key: "double")(double)
+        let result: JSON? = Encoder.encode(doubleForKey: "double")(double)
         
         XCTAssertTrue((result!["double"] as! Double == 4.0), "Encode Double should return correct value")
     }
     
     func testEncodeDoubleArray() {
-        let doubleArray: [Double]? = [4.0, 5.0, 6.0]
-        let result: JSON? = Encoder.encode(key: "doubleArray")(doubleArray)
+        let doubleArray: [Double]? = [4.0, 5, 6.0]
+        let result: JSON? = Encoder.encode(doubleArrayForKey: "doubleArray")(doubleArray)
         
         XCTAssertTrue((result!["doubleArray"] as! [Double] == [4.0, 5.0, 6.0]), "Encode Double array should return correct value")
     }

--- a/Tests/GlossTests/OperatorTests.swift
+++ b/Tests/GlossTests/OperatorTests.swift
@@ -116,14 +116,14 @@ class OperatorTests: XCTestCase {
     
     func testDecodeOperatorGenericReturnsDecoderDecodeForDouble() {
         let resultDouble: Double? = "double" <~~ testJSON!
-        let decoderResultDouble: Double? = Decoder.decode(key: "double")(testJSON!)
+        let decoderResultDouble: Double? = Decoder.decode(doubleForKey: "double")(testJSON!)
         
         XCTAssertTrue((resultDouble == decoderResultDouble), "<~~ for generic value should return same as Decoder.decode for Double")
     }
     
     func testDecodeOperatorGenericReturnsDecoderDecodeForDoubleArray() {
         let resultDoubleArray: [Double]? = "doubleArray" <~~ testJSON!
-        let decoderResultDoubleArray: [Double]? = Decoder.decode(key: "doubleArray")(testJSON!)
+        let decoderResultDoubleArray: [Double]? = Decoder.decode(doubleArrayForKey: "doubleArray")(testJSON!)
         
         XCTAssertTrue((resultDoubleArray! == decoderResultDoubleArray!), "<~~ for generic value should return same as Decoder.decode for Double array")
     }
@@ -337,15 +337,15 @@ class OperatorTests: XCTestCase {
     func testEncodeOperatorGenericReturnsEncoderEncodeForDouble() {
         let double: Double? = 1.0
         let resultDouble: JSON? = "double" ~~> double
-        let encoderResultDouble: JSON? = Encoder.encode(key: "double")(double)
+        let encoderResultDouble: JSON? = Encoder.encode(doubleForKey: "double")(double)
         
         XCTAssertTrue(((resultDouble!["double"] as! Double) == (encoderResultDouble!["double"] as! Double)), "~~> for generic value should return same as Encoder.encode for Double")
     }
     
     func testEncodeOperatorGenericReturnsEncoderEncodeForDoubleArray() {
-        let doubleArray: [Double]? = [1.0, 2.0, 3.0]
+        let doubleArray: [Double]? = [1.0, 2, 3.0]
         let resultDoubleArray: JSON? = "doubleArray" ~~> doubleArray
-        let encoderResultDoubleArray: JSON? = Encoder.encode(key: "doubleArray")(doubleArray)
+        let encoderResultDoubleArray: JSON? = Encoder.encode(doubleArrayForKey: "doubleArray")(doubleArray)
         
         XCTAssertTrue(((resultDoubleArray!["doubleArray"] as! [Double]) == (encoderResultDoubleArray!["doubleArray"] as! [Double])), "~~> for generic value should return same as Encoder.encode for Double array")
     }

--- a/Tests/GlossTests/Test Models/TestModel.json
+++ b/Tests/GlossTests/Test Models/TestModel.json
@@ -6,7 +6,7 @@
     "float" : 2.0,
     "floatArray" : [1.0, 2.0, 3.0],
     "double" : 6.0,
-    "doubleArray" : [4.0, 5.0, 6.0],
+    "doubleArray" : [4.0, 5, 6.0],
     "dictionary" : {
         "otherModel" : {
             "id" : 789,

--- a/Tests/GlossTests/Test Models/TestModel.swift
+++ b/Tests/GlossTests/Test Models/TestModel.swift
@@ -174,7 +174,7 @@ extension TestModel {
             "float" : Float(2.0),
             "floatArray" : [Float(1.0), Float(2.0), Float(3.0)],
             "double" : Double(6.0),
-            "doubleArray" : [Double(4.0), Double(5.0), Double(6.0)],
+            "doubleArray" : [Double(4.0), Double(5), Double(6.0)],
             "dictionary" : [
                 "otherModel" : [
                     "id" : 789,


### PR DESCRIPTION
First of all, what a great library! I really appreciate the work you've done and I'm using it in some of my projects.

I would like to suggest that decoding an `Integer` value to a `Double` does not return `nil`. For example, if I have the following model:

```swift
struct Example {
    let value: Double
}

extension Example: Decodable {
    init?(json: JSON) {
        guard let value: Double = "value" <~~ json else { return nil }
        self.value = value
    }
}
```

and if I try to decode this json and produce a `Example` model: 

```json
{
    "value": 0
}
```

Gloss will return a `nil` object, as it was unable to decode an `Integer` value to a `Double`. I think that this is due to the fact that 0 isn't recognised as a `Decimal` value.

A solution to this problem is adding a specific decoder for `Double`s. 

```swift
public static func decode(doubleForKey key: String, keyPathDelimiter: String = GlossKeyPathDelimiter) -> (JSON) -> Double? {
    return {
        json in
            
        if let number = json.valueForKeyPath(keyPath: key, withDelimiter: keyPathDelimiter) as? NSNumber {
            return number.doubleValue
        }
            
        return nil
    }
}
```

This allows for the key `value` to be decoded even when the underlying value is an `Integer`. This can be useful for APIs that send back 0 instead of 0.0.