### PR TITLE
Add swift_version to spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: objective-c
 osx_image: xcode9
 
 before_install:
-   - gem install cocoapods --pre --no-rdoc --no-ri --no-document --quiet
+   - gem install cocoapods --no-rdoc --no-ri --no-document --quiet
 
 script:
    - xcodebuild test -project Gloss.xcodeproj -scheme GlossTests -destination 'platform=iOS Simulator,name=iPhone 6,OS=11.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'cocoapods', :git => 'https://github.com/CocoaPods/CocoaPods.git', :tag => '1-1-stable'
+gem 'cocoapods', :git => 'https://github.com/CocoaPods/CocoaPods.git', :tag => '1.4.0'

--- a/Gloss.podspec
+++ b/Gloss.podspec
@@ -9,6 +9,7 @@ Pod::Spec.new do |s|
   s.social_media_url = "http://twitter.com/HarlanKellaway"
   s.source           = { :git => "https://github.com/hkellaway/Gloss.git", :tag => s.version.to_s }
   
+  s.swift_version    = "4.0"
   s.platforms     = { :ios => "8.0", :osx => "10.9", :tvos => "9.0", :watchos => "2.0" }
   s.requires_arc = true
 


### PR DESCRIPTION
* Specifies the swift version that will be used for the pod regardless of the swift version the app target uses.

Note: This feature was added on CocoaPods 1.4.0 (http://blog.cocoapods.org/CocoaPods-1.4.0/)