### PR TITLE
Improve usage of Data

### DIFF
--- a/Sources/Gloss/ExtensionArray.swift
+++ b/Sources/Gloss/ExtensionArray.swift
@@ -167,7 +167,7 @@ public extension Array where Element: JSONDecodable {
      */
     static func from(data: Data, serializer: JSONSerializer = GlossJSONSerializer(), options: JSONSerialization.ReadingOptions = .mutableContainers) -> [Element]? {
         guard
-            let jsonArray = (try? JSONSerialization.jsonObject(with: data, options: options)) as? [JSON],
+            let jsonArray = serializer.jsonArray(from: data, options: options),
             let models = [Element].from(jsonArray: jsonArray) else {
                 return nil
         }

--- a/Sources/Gloss/ExtensionArray.swift
+++ b/Sources/Gloss/ExtensionArray.swift
@@ -53,6 +53,35 @@ public extension Array where Element: JSONDecodable & Decodable {
         return models
     }
     
+    /**
+     Returns array of new objects created from provided data.
+     If creation of JSON or any decodings fail, nil is returned.
+     
+     - parameter data:        Raw JSON data.
+     - parameter jsonDecoder: A `Swift.JSONDecoder`.
+     - parameter serializer:  Serializer to use when creating JSON from data.
+     - parameter ooptions:    Options for reading the JSON data.
+     - parameter logger:        Logs issues with `Swift.Decodable`.
+     
+     - returns: Object or nil.
+     */
+    static func from(decodableData data: Data, jsonDecoder: JSONDecoder = JSONDecoder(), serializer: JSONSerializer = GlossJSONSerializer(), options: JSONSerialization.ReadingOptions = .mutableContainers, logger: GlossLogger = GlossLogger()) -> [Element]? {
+        do {
+            let jsonArray = try jsonDecoder.decode([Element].self, from: data)
+            return jsonArray
+        } catch {
+            logger.log(message: "Swift.Decodable error: \(error)")
+            
+            guard
+                let jsonArray = serializer.jsonArray(from: data, options: options),
+                let models = [Element].from(jsonArray: jsonArray) else {
+                    return nil
+            }
+
+            return models
+        }
+    }
+    
 }
 
 public extension Array where Element: JSONEncodable & Encodable {

--- a/Sources/GlossTests/GlossTests.swift
+++ b/Sources/GlossTests/GlossTests.swift
@@ -332,7 +332,7 @@ class GlossTests: XCTestCase {
     
     func testModelArrayFromJSONArrayRawData() {
         let data = try! JSONSerialization.data(withJSONObject: testJSONArray!, options: [])
-        let modelArray = [TestModel].from(data: data)
+        let modelArray: [TestModel]? = .from(decodableData: data)
         
         XCTAssertNotNil(modelArray, "Model array from Data should not be nil.")
     }

--- a/Sources/GlossTests/GlossTests.swift
+++ b/Sources/GlossTests/GlossTests.swift
@@ -143,7 +143,7 @@ class GlossTests: XCTestCase {
     }
     
     func testModelsFromJSONArrayProducesValidModels() {
-        let result = [TestModel].from(decodableJSONArray: testJSONArray!)
+        let result: [TestModel]? = .from(decodableJSONArray: testJSONArray!)
         let model1: TestModel = result![0]
         let model2: TestModel = result![1]
         
@@ -206,7 +206,7 @@ class GlossTests: XCTestCase {
     func testModelsFromJSONArrayReturnsNilIfDecodingFails() {
         testJSONArray![0].removeValue(forKey: "bool")
         
-        let result = [TestModel].from(decodableJSONArray: testJSONArray!)
+        let result: [TestModel]? = .from(decodableJSONArray: testJSONArray!)
 
         XCTAssertNil(result, "Model array from JSON array should be nil is any decoding fails.")
     }
@@ -303,7 +303,7 @@ class GlossTests: XCTestCase {
         invalidJSON.removeValue(forKey: "bool")
         var jsonArray = testJSONArray!
         jsonArray.append(invalidJSON)
-        let result = [TestModel].from(decodableJSONArray: jsonArray)
+        let result: [TestModel]? = .from(decodableJSONArray: jsonArray)
 
         XCTAssertNil(result, "JSON array from model array should be nil is any encoding fails.")
     }
@@ -325,7 +325,7 @@ class GlossTests: XCTestCase {
     
     func testModelFromJSONRawData() {
         let data = try! JSONSerialization.data(withJSONObject: testModelsJSON!, options: [])
-        let model = TestModel(data: data)
+        let model: TestModel? = .from(decodableData: data)
         
         XCTAssertNotNil(model, "Model from Data should not be nil.")
     }


### PR DESCRIPTION
Gloss is deprecated in favor of Swift's `Codable`. Only Issues and Pull Requests that pertain to improvements toward or better understanding migration will be addressed. See README for info.

### Acknowledgment of Deprecation

* [x] I acknowledge awareness that Gloss is deprecated in favor of Codable

### Description

Bring treatment of initialization with `Data` inline with initialization from `JSON`