### PR TITLE
Release/3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 `Gloss` adheres to [Semantic Versioning](http://semver.org/).
 
-- `3.0.X` Releases - [3.0.0](#300) | [3.1.0](#310) | [3.1.1](#311) | [3.2.0](#320)
+- `3.0.X` Releases - [3.0.0](#300) | [3.1.0](#310) | [3.1.1](#311) | [3.2.0](#320) | [3.2.1](#321)
 - `2.1.x` Releases - [2.1.0](#210) | [2.1.1](#211)
 - `2.0.x` Releases - [2.0.0-beta.1](#200-beta1) | [2.0.0-beta.2](#200-beta2) | [2.0.0](#200) | [2.0.1](#201)
 - `1.2.x` Releases - [1.2.0](#120) | [1.2.1](#121) | [1.2.2](#122) | [1.2.3](#123) | [1.2.4](#124)
@@ -16,6 +16,14 @@ All notable changes to this project will be documented in this file.
 - `0.3.x` Releases - [0.3.0](#030) | [0.3.1](#031)
 - `0.2.x` Releases - [0.2.0](#020)
 - `0.1.x` Releases - [0.1.0](#010)
+
+---
+## [3.2.1](https://github.com/hkellaway/Gloss/releases/tag/3.2.1)
+Released on 2020-09-01.
+
+#### Fixed
+- Missing ability to create JSON Arrays from Data [[PR #365](https://github.com/hkellaway/Gloss/pull/365)]
+- Not using passed parameter [[PR #361](https://github.com/hkellaway/Gloss/pull/365)]
 
 ---
 ## [3.2.0](https://github.com/hkellaway/Gloss/releases/tag/3.2.0)

--- a/Gloss.podspec
+++ b/Gloss.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name             = "Gloss"
-  s.version          = "3.2.0"
+  s.version          = "3.2.1"
   s.summary          = "[Deprecated] A shiny JSON parsing library in Swift"
   s.description      = "[Deprecated] A shiny JSON parsing library in Swift."
   s.homepage         = "https://github.com/hkellaway/Gloss"

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,6 @@ Gloss is deprecated in favor of Swift's `Codable`. Only Issues and Pull Requests
 ### Acknowledgment of Deprecation
 
 * [ ] I acknowledge awareness that Gloss is deprecated in favor of Codable
-* [ ] Are you using Gloss 3.2.x or higher?
 
 ### Description
 

--- a/Sources/Gloss/ExtensionArray.swift
+++ b/Sources/Gloss/ExtensionArray.swift
@@ -53,6 +53,35 @@ public extension Array where Element: JSONDecodable & Decodable {
         return models
     }
     
+    /**
+     Returns array of new objects created from provided data.
+     If creation of JSON or any decodings fail, nil is returned.
+     
+     - parameter data:        Raw JSON data.
+     - parameter jsonDecoder: A `Swift.JSONDecoder`.
+     - parameter serializer:  Serializer to use when creating JSON from data.
+     - parameter ooptions:    Options for reading the JSON data.
+     - parameter logger:        Logs issues with `Swift.Decodable`.
+     
+     - returns: Object or nil.
+     */
+    static func from(decodableData data: Data, jsonDecoder: JSONDecoder = JSONDecoder(), serializer: JSONSerializer = GlossJSONSerializer(), options: JSONSerialization.ReadingOptions = .mutableContainers, logger: GlossLogger = GlossLogger()) -> [Element]? {
+        do {
+            let jsonArray = try jsonDecoder.decode([Element].self, from: data)
+            return jsonArray
+        } catch {
+            logger.log(message: "Swift.Decodable error: \(error)")
+            
+            guard
+                let jsonArray = serializer.jsonArray(from: data, options: options),
+                let models = [Element].from(jsonArray: jsonArray) else {
+                    return nil
+            }
+
+            return models
+        }
+    }
+    
 }
 
 public extension Array where Element: JSONEncodable & Encodable {
@@ -138,7 +167,7 @@ public extension Array where Element: JSONDecodable {
      */
     static func from(data: Data, serializer: JSONSerializer = GlossJSONSerializer(), options: JSONSerialization.ReadingOptions = .mutableContainers) -> [Element]? {
         guard
-            let jsonArray = (try? JSONSerialization.jsonObject(with: data, options: options)) as? [JSON],
+            let jsonArray = serializer.jsonArray(from: data, options: options),
             let models = [Element].from(jsonArray: jsonArray) else {
                 return nil
         }

--- a/Sources/Gloss/ExtensionArray.swift
+++ b/Sources/Gloss/ExtensionArray.swift
@@ -137,15 +137,6 @@ public extension Array where Element: JSONDecodable {
         
         return models
     }
-    
-    /**
-     Returns array of new objects created from provided JSON array.
-     If any decodings fail, nil is returned.
-     
-     - parameter jsonArray: Array of JSON representations of objects.
-     
-     - returns: Array of objects created from JSON.
-     */
 
     /**
      Initializes array of model objects from provided data.

--- a/Sources/GlossTests/GlossTests.swift
+++ b/Sources/GlossTests/GlossTests.swift
@@ -143,7 +143,7 @@ class GlossTests: XCTestCase {
     }
     
     func testModelsFromJSONArrayProducesValidModels() {
-        let result = [TestModel].from(decodableJSONArray: testJSONArray!)
+        let result: [TestModel]? = .from(decodableJSONArray: testJSONArray!)
         let model1: TestModel = result![0]
         let model2: TestModel = result![1]
         
@@ -206,7 +206,7 @@ class GlossTests: XCTestCase {
     func testModelsFromJSONArrayReturnsNilIfDecodingFails() {
         testJSONArray![0].removeValue(forKey: "bool")
         
-        let result = [TestModel].from(decodableJSONArray: testJSONArray!)
+        let result: [TestModel]? = .from(decodableJSONArray: testJSONArray!)
 
         XCTAssertNil(result, "Model array from JSON array should be nil is any decoding fails.")
     }
@@ -303,7 +303,7 @@ class GlossTests: XCTestCase {
         invalidJSON.removeValue(forKey: "bool")
         var jsonArray = testJSONArray!
         jsonArray.append(invalidJSON)
-        let result = [TestModel].from(decodableJSONArray: jsonArray)
+        let result: [TestModel]? = .from(decodableJSONArray: jsonArray)
 
         XCTAssertNil(result, "JSON array from model array should be nil is any encoding fails.")
     }
@@ -325,14 +325,14 @@ class GlossTests: XCTestCase {
     
     func testModelFromJSONRawData() {
         let data = try! JSONSerialization.data(withJSONObject: testModelsJSON!, options: [])
-        let model = TestModel(data: data)
+        let model: TestModel? = .from(decodableData: data)
         
         XCTAssertNotNil(model, "Model from Data should not be nil.")
     }
     
     func testModelArrayFromJSONArrayRawData() {
         let data = try! JSONSerialization.data(withJSONObject: testJSONArray!, options: [])
-        let modelArray = [TestModel].from(data: data)
+        let modelArray: [TestModel]? = .from(decodableData: data)
         
         XCTAssertNotNil(modelArray, "Model array from Data should not be nil.")
     }


### PR DESCRIPTION
Gloss is deprecated in favor of Swift's `Codable`. Only Issues and Pull Requests that pertain to improvements toward or better understanding migration will be addressed. See README for info.

### Acknowledgment of Deprecation

* [x] I acknowledge awareness that Gloss is deprecated in favor of Codable

